### PR TITLE
Feat/#5 product create

### DIFF
--- a/product-service/src/main/java/com/springcloud/eureka/client/productservice/application/service/ProductService.java
+++ b/product-service/src/main/java/com/springcloud/eureka/client/productservice/application/service/ProductService.java
@@ -1,0 +1,28 @@
+package com.springcloud.eureka.client.productservice.application.service;
+
+import com.springcloud.eureka.client.productservice.domain.entity.Product;
+import com.springcloud.eureka.client.productservice.infrastructure.repository.ProductRepository;
+import com.springcloud.eureka.client.productservice.presentation.dto.RepProductCreateDto;
+import com.springcloud.eureka.client.productservice.presentation.dto.ReqProductCreateDto;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+
+@Service
+public class ProductService {
+
+    private final ProductRepository productRepository;
+
+    public ProductService(ProductRepository productRepository){
+        this.productRepository = productRepository;
+    }
+
+    // 상품 생성
+    public RepProductCreateDto createProduct(String userId, ReqProductCreateDto request){
+        Product product = request.toEntity(userId);
+        product.setCreate(Instant.now(), userId);
+        Product saved = productRepository.save(product);
+        return RepProductCreateDto.from(saved);
+    }
+
+}

--- a/product-service/src/main/java/com/springcloud/eureka/client/productservice/application/service/ProductService.java
+++ b/product-service/src/main/java/com/springcloud/eureka/client/productservice/application/service/ProductService.java
@@ -5,10 +5,12 @@ import com.springcloud.eureka.client.productservice.infrastructure.repository.Pr
 import com.springcloud.eureka.client.productservice.presentation.dto.RepProductCreateDto;
 import com.springcloud.eureka.client.productservice.presentation.dto.ReqProductCreateDto;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
 
 @Service
+@Transactional
 public class ProductService {
 
     private final ProductRepository productRepository;

--- a/product-service/src/main/java/com/springcloud/eureka/client/productservice/domain/entity/Product.java
+++ b/product-service/src/main/java/com/springcloud/eureka/client/productservice/domain/entity/Product.java
@@ -1,0 +1,51 @@
+package com.springcloud.eureka.client.productservice.domain.entity;
+
+import com.javaauction.global.infrastructure.entity.BaseEntity;
+import com.springcloud.eureka.client.productservice.domain.enums.ProductStatus;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@Entity
+@Table(name = "p_product")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Product extends BaseEntity {
+    @Id
+    @Column(name = "product_id", nullable = false, updatable = false, length = 36)
+    private String id;
+
+    @Column(name = "user_id", nullable = false, length = 50)
+    private String userId;
+
+    @Column(name = "name", nullable = false, length = 100)
+    private String name;
+
+    @Column(name = "description")
+    private String description;
+
+    @Column(name = "image_url", length = 500)
+    private String imageUrl;   // S3 등 외부 저장소 URL
+
+    @Column(name = "final_price")
+    private Long finalPrice;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "product_status", nullable = false, length = 30)
+    private ProductStatus status;
+
+    public static Product create(String userId, String name, String description, String imageUrl) {
+        Product product = new Product();
+        product.id = UUID.randomUUID().toString();
+        product.userId = userId;
+        product.name = name;
+        product.description = description;
+        product.imageUrl = imageUrl;
+        product.status = ProductStatus.AUCTION_WAITING;
+        return product;
+    }
+
+}

--- a/product-service/src/main/java/com/springcloud/eureka/client/productservice/domain/entity/Product.java
+++ b/product-service/src/main/java/com/springcloud/eureka/client/productservice/domain/entity/Product.java
@@ -15,8 +15,9 @@ import java.util.UUID;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Product extends BaseEntity {
     @Id
-    @Column(name = "product_id", nullable = false, updatable = false, length = 36)
-    private String id;
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "product_id", nullable = false, updatable = false)
+    private UUID id;
 
     @Column(name = "user_id", nullable = false, length = 50)
     private String userId;
@@ -39,7 +40,6 @@ public class Product extends BaseEntity {
 
     public static Product create(String userId, String name, String description, String imageUrl) {
         Product product = new Product();
-        product.id = UUID.randomUUID().toString();
         product.userId = userId;
         product.name = name;
         product.description = description;

--- a/product-service/src/main/java/com/springcloud/eureka/client/productservice/domain/enums/ProductStatus.java
+++ b/product-service/src/main/java/com/springcloud/eureka/client/productservice/domain/enums/ProductStatus.java
@@ -1,0 +1,7 @@
+package com.springcloud.eureka.client.productservice.domain.enums;
+
+public enum ProductStatus {
+    AUCTION_WAITING, // 경매 대기
+    AUCTION_RUNNING, // 경매 중
+    SOLD // 판매 완료
+}

--- a/product-service/src/main/java/com/springcloud/eureka/client/productservice/infrastructure/repository/ProductRepository.java
+++ b/product-service/src/main/java/com/springcloud/eureka/client/productservice/infrastructure/repository/ProductRepository.java
@@ -1,0 +1,8 @@
+package com.springcloud.eureka.client.productservice.infrastructure.repository;
+
+import com.springcloud.eureka.client.productservice.domain.entity.Product;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductRepository extends JpaRepository<Product, String> {
+
+}

--- a/product-service/src/main/java/com/springcloud/eureka/client/productservice/infrastructure/repository/ProductRepository.java
+++ b/product-service/src/main/java/com/springcloud/eureka/client/productservice/infrastructure/repository/ProductRepository.java
@@ -3,6 +3,8 @@ package com.springcloud.eureka.client.productservice.infrastructure.repository;
 import com.springcloud.eureka.client.productservice.domain.entity.Product;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ProductRepository extends JpaRepository<Product, String> {
+import java.util.UUID;
+
+public interface ProductRepository extends JpaRepository<Product, UUID> {
 
 }

--- a/product-service/src/main/java/com/springcloud/eureka/client/productservice/presentation/controller/ProductController.java
+++ b/product-service/src/main/java/com/springcloud/eureka/client/productservice/presentation/controller/ProductController.java
@@ -1,0 +1,36 @@
+package com.springcloud.eureka.client.productservice.presentation.controller;
+
+import com.javaauction.global.infrastructure.code.BaseSuccessCode;
+import com.javaauction.global.presentation.response.ApiResponse;
+import com.springcloud.eureka.client.productservice.application.service.ProductService;
+import com.springcloud.eureka.client.productservice.presentation.dto.RepProductCreateDto;
+import com.springcloud.eureka.client.productservice.presentation.dto.ReqProductCreateDto;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1/products")
+public class ProductController {
+    private final ProductService productService;
+
+    public ProductController(ProductService productService) {
+        this.productService = productService;
+    }
+
+    // 상품 등록
+    @PostMapping
+    public ResponseEntity<ApiResponse<RepProductCreateDto>> createProduct(@Valid @RequestBody ReqProductCreateDto request) {
+        // Security 적용 후, 실제 유저 ID를 인증 컨텍스트에서 꺼내오기
+        String mockUserId = "TEMP-USER";  // 현재는 임시 하드코딩
+
+        RepProductCreateDto response = productService.createProduct(mockUserId, request);
+
+        return ResponseEntity
+                .status(BaseSuccessCode.CREATED.getStatus())
+                .body(ApiResponse.success(BaseSuccessCode.CREATED, response));
+    }
+}

--- a/product-service/src/main/java/com/springcloud/eureka/client/productservice/presentation/dto/RepProductCreateDto.java
+++ b/product-service/src/main/java/com/springcloud/eureka/client/productservice/presentation/dto/RepProductCreateDto.java
@@ -6,11 +6,12 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.time.Instant;
+import java.util.UUID;
 
 @Getter
 @Builder
 public class RepProductCreateDto {
-    private String productId;
+    private UUID productId;
     private String userId;
     private String name;
     private String description;

--- a/product-service/src/main/java/com/springcloud/eureka/client/productservice/presentation/dto/RepProductCreateDto.java
+++ b/product-service/src/main/java/com/springcloud/eureka/client/productservice/presentation/dto/RepProductCreateDto.java
@@ -1,0 +1,38 @@
+package com.springcloud.eureka.client.productservice.presentation.dto;
+
+import com.springcloud.eureka.client.productservice.domain.entity.Product;
+import com.springcloud.eureka.client.productservice.domain.enums.ProductStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.Instant;
+
+@Getter
+@Builder
+public class RepProductCreateDto {
+    private String productId;
+    private String userId;
+    private String name;
+    private String description;
+    private String imageUrl;
+    private Long finalPrice;
+    private ProductStatus productStatus;
+    private Instant createdAt;
+    private Instant updatedAt;
+    private Instant deletedAt;
+
+    public static RepProductCreateDto from(Product product) {
+        return RepProductCreateDto.builder()
+                .productId(product.getId())
+                .userId(product.getUserId())
+                .name(product.getName())
+                .description(product.getDescription())
+                .imageUrl(product.getImageUrl())
+                .finalPrice(product.getFinalPrice())
+                .productStatus(product.getStatus())
+                .createdAt(product.getCreatedAt())
+                .updatedAt(product.getUpdatedAt())
+                .deletedAt(product.getDeletedAt())
+                .build();
+    }
+}

--- a/product-service/src/main/java/com/springcloud/eureka/client/productservice/presentation/dto/ReqProductCreateDto.java
+++ b/product-service/src/main/java/com/springcloud/eureka/client/productservice/presentation/dto/ReqProductCreateDto.java
@@ -1,0 +1,29 @@
+package com.springcloud.eureka.client.productservice.presentation.dto;
+
+import com.springcloud.eureka.client.productservice.domain.entity.Product;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class ReqProductCreateDto {
+
+    @NotBlank
+    private String name;
+
+    private String description;
+
+    private  String imageUrl;
+
+    public Product toEntity(String userId) {
+        return Product.create(
+                userId,
+                this.name,
+                this.description,
+                this.imageUrl
+        );
+    }
+}


### PR DESCRIPTION
## 📎 관련 이슈
- 관련 이슈 번호를 연결해주세요.  
  #5 

---

## 📢 개요(Summary)
상품 서비스 모듈에 상품 도메인과 상품 생성 API를 추가 (인증/인가 미적용 , 추후에 적용 예정)

---

## 🔧 변경 사항(Details)
구체적으로 어떤 변경이 이루어졌는지 작성해주세요.

- Product 도메인 추가  
  - `Product` 엔티티 및 `ProductStatus` enum 정의  
  - JPA 매핑 적용 및 BaseEntity 상속으로 생성/수정/삭제 메타데이터 관리

- 저장 레이어 및 서비스 로직 구현  
  - `ProductRepository` 생성 (Spring Data JPA)  
  - `ProductService.createProduct` 에서 DTO → 엔티티 변환, 저장, 응답 DTO 변환 처리

- 상품 생성 API 및 DTO 추가  
  - `ReqProductCreateDto`, `RepProductCreateDto` 작성  
  - `POST /v1/products` 엔드포인트 구현 (`ProductController`)  
  - 공통 `ApiResponse` + `BaseSuccessCode.CREATED` 포맷으로 응답 반환

---

## ✔️ 테스트 방법(Test)

<img width="725" height="683" alt="image" src="https://github.com/user-attachments/assets/3fb1c7f0-1f13-49d8-8750-e7f49049f497" />

<img width="1109" height="220" alt="image" src="https://github.com/user-attachments/assets/f6ee0f8a-c5ee-41ff-9890-dd7bb72e3d4a" />


---
