### PR TITLE
Feat/#5 product update & delete

### DIFF
--- a/product-service/src/main/java/com/springcloud/eureka/client/productservice/application/service/ProductService.java
+++ b/product-service/src/main/java/com/springcloud/eureka/client/productservice/application/service/ProductService.java
@@ -8,6 +8,7 @@ import com.springcloud.eureka.client.productservice.infrastructure.repository.Pr
 import com.springcloud.eureka.client.productservice.presentation.dto.RepProductDto;
 import com.springcloud.eureka.client.productservice.presentation.dto.RepProductPageDto;
 import com.springcloud.eureka.client.productservice.presentation.dto.ReqProductCreateDto;
+import com.springcloud.eureka.client.productservice.presentation.dto.ReqProductUpdateDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -72,6 +73,26 @@ public class ProductService {
         Product product = productRepository.findById(productId)
                 .orElseThrow(() -> new BussinessException(ProductErrorCode.PRODUCT_NOT_FOUND));
         return product.getName();
+    }
+
+    // 상품 정보 수정
+    public RepProductDto updateProduct(UUID productId, ReqProductUpdateDto request, String userId) {
+        Product product = productRepository.findById(productId)
+                .orElseThrow(() -> new BussinessException(ProductErrorCode.PRODUCT_NOT_FOUND));
+
+        if (request.getName() != null) {
+            product.changeName(request.getName());
+        }
+        if (request.getDescription() != null) {
+            product.changeDescription(request.getDescription());
+        }
+        if (request.getImageUrl() != null) {
+            product.changeImageUrl(request.getImageUrl());
+        }
+
+        product.setUpdated(Instant.now(), userId);
+
+        return RepProductDto.from(product);
     }
 
 }

--- a/product-service/src/main/java/com/springcloud/eureka/client/productservice/application/service/ProductService.java
+++ b/product-service/src/main/java/com/springcloud/eureka/client/productservice/application/service/ProductService.java
@@ -104,4 +104,12 @@ public class ProductService {
         return RepProductDto.from(product);
     }
 
+    // 상품 논리 삭제
+    public void deleteProduct(UUID productId, String userId) {
+        Product product = productRepository.findById(productId)
+                .orElseThrow(() -> new BussinessException(ProductErrorCode.PRODUCT_NOT_FOUND));
+
+        product.softDelete(Instant.now(), userId);
+    }
+
 }

--- a/product-service/src/main/java/com/springcloud/eureka/client/productservice/application/service/ProductService.java
+++ b/product-service/src/main/java/com/springcloud/eureka/client/productservice/application/service/ProductService.java
@@ -5,10 +5,7 @@ import com.springcloud.eureka.client.productservice.domain.entity.Product;
 import com.springcloud.eureka.client.productservice.domain.enums.ProductStatus;
 import com.springcloud.eureka.client.productservice.domain.error.ProductErrorCode;
 import com.springcloud.eureka.client.productservice.infrastructure.repository.ProductRepository;
-import com.springcloud.eureka.client.productservice.presentation.dto.RepProductDto;
-import com.springcloud.eureka.client.productservice.presentation.dto.RepProductPageDto;
-import com.springcloud.eureka.client.productservice.presentation.dto.ReqProductCreateDto;
-import com.springcloud.eureka.client.productservice.presentation.dto.ReqProductUpdateDto;
+import com.springcloud.eureka.client.productservice.presentation.dto.*;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -90,6 +87,18 @@ public class ProductService {
             product.changeImageUrl(request.getImageUrl());
         }
 
+        product.setUpdated(Instant.now(), userId);
+
+        return RepProductDto.from(product);
+    }
+
+    // 상품 상태 변경 (판매 완료)
+    public RepProductDto updateProductStatus(UUID productId, ReqProductStatusUpdateDto request, String userId) {
+        Product product = productRepository.findById(productId)
+                .orElseThrow(() -> new BussinessException(ProductErrorCode.PRODUCT_NOT_FOUND));
+
+        // SOLD 등으로 상태 변경
+        product.changeStatus(request.getProductStatus(), request.getFinalPrice());
         product.setUpdated(Instant.now(), userId);
 
         return RepProductDto.from(product);

--- a/product-service/src/main/java/com/springcloud/eureka/client/productservice/domain/entity/Product.java
+++ b/product-service/src/main/java/com/springcloud/eureka/client/productservice/domain/entity/Product.java
@@ -54,10 +54,15 @@ public class Product extends BaseEntity {
     }
 
     public void changeDescription(String description) {
-        this.description = name;
+        this.description = description;
     }
 
     public void changeImageUrl(String imageUrl) {
         this.imageUrl = imageUrl;
+    }
+
+    public void changeStatus(ProductStatus productStatus, Long finalPrice) {
+        this.status =productStatus;
+        this.finalPrice = finalPrice;
     }
 }

--- a/product-service/src/main/java/com/springcloud/eureka/client/productservice/domain/entity/Product.java
+++ b/product-service/src/main/java/com/springcloud/eureka/client/productservice/domain/entity/Product.java
@@ -6,6 +6,7 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.util.UUID;
 
@@ -48,4 +49,15 @@ public class Product extends BaseEntity {
         return product;
     }
 
+    public void changeName(String name) {
+        this.name = name;
+    }
+
+    public void changeDescription(String description) {
+        this.description = name;
+    }
+
+    public void changeImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
 }

--- a/product-service/src/main/java/com/springcloud/eureka/client/productservice/presentation/controller/ProductController.java
+++ b/product-service/src/main/java/com/springcloud/eureka/client/productservice/presentation/controller/ProductController.java
@@ -4,10 +4,7 @@ import com.javaauction.global.infrastructure.code.BaseSuccessCode;
 import com.javaauction.global.presentation.response.ApiResponse;
 import com.springcloud.eureka.client.productservice.application.service.ProductService;
 import com.springcloud.eureka.client.productservice.domain.enums.ProductStatus;
-import com.springcloud.eureka.client.productservice.presentation.dto.RepProductDto;
-import com.springcloud.eureka.client.productservice.presentation.dto.RepProductPageDto;
-import com.springcloud.eureka.client.productservice.presentation.dto.ReqProductCreateDto;
-import com.springcloud.eureka.client.productservice.presentation.dto.ReqProductUpdateDto;
+import com.springcloud.eureka.client.productservice.presentation.dto.*;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -80,4 +77,16 @@ public class ProductController {
         RepProductDto response = productService.updateProduct(productId, request, mockUserId);
         return ResponseEntity.ok(ApiResponse.success(BaseSuccessCode.OK, response));
     }
+
+    // 상품 상태변경 (판매완료)
+    @PutMapping("/{productId}/status")
+    public ResponseEntity<ApiResponse<RepProductDto>> updateProductStatus(
+            @PathVariable UUID productId,
+            @RequestBody ReqProductStatusUpdateDto request
+    ) {
+        String mockUserId = "TEMP-USER";
+        RepProductDto response = productService.updateProductStatus(productId, request, mockUserId);
+        return ResponseEntity.ok(ApiResponse.success(BaseSuccessCode.OK, response));
+    }
+
 }

--- a/product-service/src/main/java/com/springcloud/eureka/client/productservice/presentation/controller/ProductController.java
+++ b/product-service/src/main/java/com/springcloud/eureka/client/productservice/presentation/controller/ProductController.java
@@ -7,6 +7,7 @@ import com.springcloud.eureka.client.productservice.domain.enums.ProductStatus;
 import com.springcloud.eureka.client.productservice.presentation.dto.RepProductDto;
 import com.springcloud.eureka.client.productservice.presentation.dto.RepProductPageDto;
 import com.springcloud.eureka.client.productservice.presentation.dto.ReqProductCreateDto;
+import com.springcloud.eureka.client.productservice.presentation.dto.ReqProductUpdateDto;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -66,6 +67,17 @@ public class ProductController {
     ) {
         String name = productService.getProductName(productId);
         Map<String, String> response = Map.of("productName", name);
+        return ResponseEntity.ok(ApiResponse.success(BaseSuccessCode.OK, response));
+    }
+
+    // 상품 정보 수정
+    @PutMapping("/{productId}")
+    public ResponseEntity<ApiResponse<RepProductDto>> updateProduct(
+            @PathVariable UUID productId,
+            @RequestBody ReqProductUpdateDto request
+    ) {
+        String mockUserId = "TEMP-USER";
+        RepProductDto response = productService.updateProduct(productId, request, mockUserId);
         return ResponseEntity.ok(ApiResponse.success(BaseSuccessCode.OK, response));
     }
 }

--- a/product-service/src/main/java/com/springcloud/eureka/client/productservice/presentation/controller/ProductController.java
+++ b/product-service/src/main/java/com/springcloud/eureka/client/productservice/presentation/controller/ProductController.java
@@ -89,4 +89,15 @@ public class ProductController {
         return ResponseEntity.ok(ApiResponse.success(BaseSuccessCode.OK, response));
     }
 
+    // 상품 논리 삭제
+    @DeleteMapping("/{productId}")
+    public ResponseEntity<ApiResponse<Map<String, String>>> deleteProduct(
+            @PathVariable UUID productId
+    ) {
+        String mockUserId = "TEMP-USER";
+        productService.deleteProduct(productId, mockUserId);
+        Map<String, String> body = Map.of("result", "success");
+        return ResponseEntity.ok(ApiResponse.success(BaseSuccessCode.OK, body));
+    }
+
 }

--- a/product-service/src/main/java/com/springcloud/eureka/client/productservice/presentation/dto/ReqProductStatusUpdateDto.java
+++ b/product-service/src/main/java/com/springcloud/eureka/client/productservice/presentation/dto/ReqProductStatusUpdateDto.java
@@ -1,0 +1,14 @@
+package com.springcloud.eureka.client.productservice.presentation.dto;
+
+import com.springcloud.eureka.client.productservice.domain.enums.ProductStatus;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class ReqProductStatusUpdateDto {
+    private ProductStatus productStatus;
+    private Long finalPrice;
+}

--- a/product-service/src/main/java/com/springcloud/eureka/client/productservice/presentation/dto/ReqProductUpdateDto.java
+++ b/product-service/src/main/java/com/springcloud/eureka/client/productservice/presentation/dto/ReqProductUpdateDto.java
@@ -1,0 +1,14 @@
+package com.springcloud.eureka.client.productservice.presentation.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class ReqProductUpdateDto {
+    private String name;
+    private String description;
+    private String imageUrl;
+}


### PR DESCRIPTION
## 📎 관련 이슈
- 관련 이슈 번호를 연결해주세요.  
  #5 

---

## 📢 개요(Summary)
상품 수정 · 상태 변경 · 논리 삭제 기능을 추가하여 상품 도메인의 기본 CRUD 기능을 완성

---

## 🔧 변경 사항(Details)

- 상품 정보 수정 API 구현  
- 상품 상태 변경 (상품 판매 완료) API 구현   
- 상품 논리 삭제 API 구현  

---

## ✔️ 테스트 방법(Test)

<img width="1810" height="1644" alt="image" src="https://github.com/user-attachments/assets/f91f85e6-f9a4-4d6e-88cd-519089b1605e" />
<img width="1800" height="1658" alt="image" src="https://github.com/user-attachments/assets/5ebe9e29-ef98-4556-9c9f-709eff5a3f32" />
<img width="1788" height="1234" alt="image" src="https://github.com/user-attachments/assets/8530dca6-4c1f-4fa3-a6b2-7404a9fd5c00" />
<img width="3074" height="444" alt="image" src="https://github.com/user-attachments/assets/18e68746-0b09-4796-a9be-9514a96cd8e3" />


---
