### PR TITLE
Feat/#53 알림 생성(내부 API) 리팩토링

### DIFF
--- a/alert-service/build.gradle
+++ b/alert-service/build.gradle
@@ -46,7 +46,7 @@ dependencies {
     implementation 'org.jetbrains:annotations:24.1.0'
 
     compileOnly 'org.projectlombok:lombok'
-    runtimeOnly 'com.h2database:h2'
+    runtimeOnly 'org.postgresql:postgresql'
     annotationProcessor 'org.projectlombok:lombok'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'

--- a/alert-service/src/main/java/com/javaauction/alertservice/AlertServiceApplication.java
+++ b/alert-service/src/main/java/com/javaauction/alertservice/AlertServiceApplication.java
@@ -2,7 +2,11 @@ package com.javaauction.alertservice;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
+@EnableFeignClients
+@EnableDiscoveryClient
 @SpringBootApplication
 public class AlertServiceApplication {
 

--- a/alert-service/src/main/java/com/javaauction/alertservice/application/client/SlackClientV1.java
+++ b/alert-service/src/main/java/com/javaauction/alertservice/application/client/SlackClientV1.java
@@ -1,0 +1,30 @@
+package com.javaauction.alertservice.application.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+import java.util.Map;
+
+@FeignClient(
+        name = "slackClient",
+        url = "https://slack.com/api"
+)
+
+public interface SlackClientV1 {
+
+    @PostMapping(value = "/conversations.open", consumes = MediaType.APPLICATION_JSON_VALUE)
+    Map<String, Object> openConversation(
+            @RequestHeader("Authorization") String bearerToken,
+            @RequestBody Map<String, Object> body
+    );
+
+    @PostMapping(value = "/chat.postMessage", consumes = MediaType.APPLICATION_JSON_VALUE)
+    Map<String, Object> postMessage(
+            @RequestHeader("Authorization") String bearerToken,
+            @RequestBody Map<String, Object> body
+    );
+
+}

--- a/alert-service/src/main/java/com/javaauction/alertservice/application/client/UserClientV1.java
+++ b/alert-service/src/main/java/com/javaauction/alertservice/application/client/UserClientV1.java
@@ -1,0 +1,13 @@
+package com.javaauction.alertservice.application.client;
+
+import com.javaauction.alertservice.presentation.dto.response.RepGetInternalUsersDtoV1;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@FeignClient(name = "user-service")
+public interface UserClientV1 {
+    @GetMapping("/internal/users/{userId}")
+    RepGetInternalUsersDtoV1 getUser(@PathVariable("userId") String userId);
+
+}

--- a/alert-service/src/main/java/com/javaauction/alertservice/infrastructure/config/JpaAuditingConfig.java
+++ b/alert-service/src/main/java/com/javaauction/alertservice/infrastructure/config/JpaAuditingConfig.java
@@ -4,16 +4,30 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 
 import java.util.Optional;
+
+import jakarta.servlet.http.HttpServletRequest;
 
 @Configuration
 @EnableJpaAuditing(auditorAwareRef = "auditorAware")
 public class JpaAuditingConfig {
+
     @Bean
     public AuditorAware<String> auditorAware() {
-        // 임시값 사용
-        return () -> Optional.of("tmpuser1");
-    }
+        return () -> {
+            // 현재 요청에서 사용자 헤더 가져오기
+            ServletRequestAttributes attrs = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+            if (attrs == null) {
+                return Optional.of("system"); // 요청 없으면 system 처리
+            }
 
+            HttpServletRequest request = attrs.getRequest();
+            String username = request.getHeader("X-User-Username");
+
+            return Optional.ofNullable(username).or(() -> Optional.of("system"));
+        };
+    }
 }

--- a/alert-service/src/main/java/com/javaauction/alertservice/presentation/advice/AlertErrorCode.java
+++ b/alert-service/src/main/java/com/javaauction/alertservice/presentation/advice/AlertErrorCode.java
@@ -7,8 +7,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum AlertErrorCode implements ResponseCode {
     ALERT_NOT_FOUND("ALERT000", "해당 알림을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
-    ALERT_PRODUCT_NOT_FOUND("ALERT001", "해당 상품을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
-    ALERT_UNAUTH("ALERT002", "일반 회원은 자신의 알림만 접근 및 삭제 가능합니다.", HttpStatus.UNAUTHORIZED);
+    ALERT_UNAUTH("ALERT001", "일반 회원은 자신의 알림만 접근 및 삭제 가능합니다.", HttpStatus.UNAUTHORIZED);
 
     private final String code;
     private final String message;

--- a/alert-service/src/main/java/com/javaauction/alertservice/presentation/advice/AlertSuccessCode.java
+++ b/alert-service/src/main/java/com/javaauction/alertservice/presentation/advice/AlertSuccessCode.java
@@ -15,5 +15,5 @@ public enum AlertSuccessCode implements ResponseCode {
     private final HttpStatus status;
     private final String code;
     private final String message;
-;
+
 }

--- a/alert-service/src/main/java/com/javaauction/alertservice/presentation/controller/InternalAlertControllerV1.java
+++ b/alert-service/src/main/java/com/javaauction/alertservice/presentation/controller/InternalAlertControllerV1.java
@@ -20,8 +20,8 @@ public class InternalAlertControllerV1 {
 
     // 알림 생성
     @PostMapping
-    public ResponseEntity<ApiResponse<RepPostInternalAlertsDtoV1>> createAlert(@RequestBody ReqPostInternalAlertsDtoV1 request) {
-        RepPostInternalAlertsDtoV1 postInternalAlertsDto = alertService.postInternalAlertsDtoV1(request);
+    public ResponseEntity<ApiResponse<RepPostInternalAlertsDtoV1>> createAlert(@RequestBody ReqPostInternalAlertsDtoV1 reqDto) {
+        RepPostInternalAlertsDtoV1 postInternalAlertsDto = alertService.postInternalAlerts(reqDto);
         return ResponseEntity.ok(ApiResponse.success(AlertSuccessCode.ALERT_CREATE_SUCCESS, postInternalAlertsDto));
     }
 }

--- a/alert-service/src/main/java/com/javaauction/alertservice/presentation/dto/request/ReqPostInternalAlertsDtoV1.java
+++ b/alert-service/src/main/java/com/javaauction/alertservice/presentation/dto/request/ReqPostInternalAlertsDtoV1.java
@@ -14,5 +14,7 @@ import java.util.UUID;
 @AllArgsConstructor
 public class ReqPostInternalAlertsDtoV1 {
     private UUID auctionId;
+    private String userId;
     private AlertType alertType;
+    private String content;
 }

--- a/alert-service/src/main/java/com/javaauction/alertservice/presentation/dto/response/RepGetInternalUsersDtoV1.java
+++ b/alert-service/src/main/java/com/javaauction/alertservice/presentation/dto/response/RepGetInternalUsersDtoV1.java
@@ -1,0 +1,18 @@
+package com.javaauction.alertservice.presentation.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RepGetInternalUsersDtoV1 {
+    private String username;
+    private String email;
+    private String address;
+    private String slackId;
+    private String role;
+}

--- a/alert-service/src/main/resources/application.yml
+++ b/alert-service/src/main/resources/application.yml
@@ -6,20 +6,19 @@ spring:
     name: alert-service
 
   datasource:
-    driver-class-name: org.h2.Driver
-    url: jdbc:h2:mem:testdb;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false
-    username: sa
-    password:
+    url: jdbc:postgresql://localhost:5432/alert_db
+    username: javaauction
+    password: 1234
+    driver-class-name: org.postgresql.Driver
 
   jpa:
     hibernate:
       ddl-auto: update
     show-sql: true
-    database-platform: org.hibernate.dialect.H2Dialect
-  h2:
-    console:
-      enabled: true
-      path: /h2-console
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.PostgreSQLDialect
 
 eureka:
   client:
@@ -27,3 +26,7 @@ eureka:
     fetch-registry: true
     service-url:
       defaultZone: http://localhost:19090/eureka/
+
+slack:
+  bot:
+    token: ${SLACK_BOT_TOKEN}


### PR DESCRIPTION
## 📎 관련 이슈
- 관련 이슈 번호를 연결해주세요.  
  #53 

---

## 📢 개요(Summary)
알림 생성(내부 API) 리팩토링

---

## 🔧 변경 사항(Details)

- 경매 서비스에서 입찰, 낙찰 등의 이벤트 발생 시 요청을 보낼 수 있도록 DTO 및 서비스 로직 변경
- 유저 서비스를 호출하여 가져온 회원의 슬랙 ID로 알림 메시지 발송

---

## ✔️ 테스트 방법(Test)

- 게이트웨이를 통한 알림 생성 요청
<img width="1051" height="1288" alt="image" src="https://github.com/user-attachments/assets/251ffdaa-f5dc-4066-bab7-5ad535893eb9" />

- 슬랙 알림 발송
<img width="909" height="1023" alt="image" src="https://github.com/user-attachments/assets/62cee46e-8723-4f45-96b2-239c77228889" />

---
