### PR TITLE
Feat/#40 입찰금 결제 API

### DIFF
--- a/payment-service/src/main/java/com/javaauction/payment_service/presentation/advice/PaymentSuccessCode.java
+++ b/payment-service/src/main/java/com/javaauction/payment_service/presentation/advice/PaymentSuccessCode.java
@@ -16,7 +16,7 @@ public enum PaymentSuccessCode implements ResponseCode {
     WALLET_DEDUCT_SUCCESS(HttpStatus.OK, "PAYMENT204", "잔액 차감 성공"),
     WALLET_VALIDATE_SUCCESS(HttpStatus.OK, "PAYMENT205", "잔액 검증 성공"),
     WALLET_TRANSACTION_READ_SUCCESS(HttpStatus.OK, "PAYMENT206", "거래 내역 조회 성공"),
-    WALLET_TRANSACTION_SETTLEMENT_SUCCESS(HttpStatus.OK, "PAYMENT207", "정산 성공"),
+    WALLET_TRANSACTION_HOLD_CAPTURED_SUCCESS(HttpStatus.OK, "PAYMENT207", "입찰금 결제 성공"),
     ;
 
     private final HttpStatus status;

--- a/payment-service/src/main/java/com/javaauction/payment_service/presentation/controller/InternalWalletTransactionControllerV1.java
+++ b/payment-service/src/main/java/com/javaauction/payment_service/presentation/controller/InternalWalletTransactionControllerV1.java
@@ -1,0 +1,32 @@
+package com.javaauction.payment_service.presentation.controller;
+
+import com.javaauction.global.presentation.response.ApiResponse;
+import com.javaauction.payment_service.application.service.WalletTransactionServiceV1;
+import com.javaauction.payment_service.presentation.dto.request.ReqCaptureDto;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.javaauction.payment_service.presentation.advice.PaymentSuccessCode.WALLET_TRANSACTION_HOLD_CAPTURED_SUCCESS;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/internal/wallets/transactions")
+public class InternalWalletTransactionControllerV1 {
+
+    private final WalletTransactionServiceV1 walletTransactionService;
+
+    @PostMapping("/capture")
+    public ResponseEntity<ApiResponse<Void>> capture(@Valid @RequestBody ReqCaptureDto request) {
+        walletTransactionService.capture(request);
+
+        return ResponseEntity.status(HttpStatus.OK).body(
+                ApiResponse.success(WALLET_TRANSACTION_HOLD_CAPTURED_SUCCESS)
+        );
+    }
+}

--- a/payment-service/src/main/java/com/javaauction/payment_service/presentation/dto/request/ReqCaptureDto.java
+++ b/payment-service/src/main/java/com/javaauction/payment_service/presentation/dto/request/ReqCaptureDto.java
@@ -1,0 +1,17 @@
+package com.javaauction.payment_service.presentation.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReqCaptureDto {
+
+    @NotNull
+    private UUID auctionId;
+}


### PR DESCRIPTION
## 📎 관련 이슈
- 관련 이슈 번호를 연결해주세요.  
#40 

---

## 📢 개요(Summary)
이번 PR에서 어떤 작업을 했는지 한눈에 파악할 수 있도록 요약해주세요.

- 낙찰자의 입찰금을 결제하는 API 구현

---

## 🔧 변경 사항(Details)
구체적으로 어떤 변경이 이루어졌는지 작성해주세요.

- InternalWalletController 생성 및 입찰금 결제 API 추가
    - 특정 경매에 대한 최종 입찰금 결제 (HOLD_ACTIVE -> HOLD_CATURED)

---

## ✔️ 테스트 방법(Test)
해당 PR을 검증하기 위해 실행해야 할 테스트 방법을 작성해주세요.
### 경매에서 최종 낙찰자의 입찰금 결제
<img width="618" height="398" alt="image" src="https://github.com/user-attachments/assets/c9162ab7-66ae-46c7-95bb-396be8ececc8" />
<img width="1093" height="21" alt="image" src="https://github.com/user-attachments/assets/f01e2f5d-a1c6-43a0-9085-9803c505c4d5" />

### 입찰금 정보를 찾을 수 없을 때(이미 종료된 경매 또는 잘못된 경매 식별자)
<img width="624" height="412" alt="image" src="https://github.com/user-attachments/assets/eb5cd5ac-70bc-4c7d-b9b5-03905cda9c11" />

---
