### PR TITLE
Feat/#2 chat update(읽음 처리)

### DIFF
--- a/chat-service/src/main/java/com/javaauction/chatservice/infrastructure/repository/ChatroomJpaRepository.java
+++ b/chat-service/src/main/java/com/javaauction/chatservice/infrastructure/repository/ChatroomJpaRepository.java
@@ -9,4 +9,11 @@ import java.util.UUID;
 public interface ChatroomJpaRepository extends JpaRepository<Chatroom, UUID>, ChatroomRepository {
     // 채팅방 존재 여부 확인
     Optional<Chatroom> findByChatroomIdAndDeletedAtIsNull(UUID chatroomId);
+
+    // 채팅방 중복 체크
+    boolean existsByProductIdAndChatroomHostAndChatroomGuestAndDeletedAtIsNull(
+            UUID productId,
+            String chatroomHost,
+            String chatroomGuest
+    );
 }

--- a/chat-service/src/main/java/com/javaauction/chatservice/infrastructure/repository/ChattingJpaRepository.java
+++ b/chat-service/src/main/java/com/javaauction/chatservice/infrastructure/repository/ChattingJpaRepository.java
@@ -1,10 +1,38 @@
 package com.javaauction.chatservice.infrastructure.repository;
 
 import com.javaauction.chatservice.domain.entity.Chatting;
+import feign.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface ChattingJpaRepository extends JpaRepository<Chatting, UUID>, ChattingRepository{
+
+
+    // 읽지 않은 채팅 리스트 받아오기
+    @Query("""
+        select c.chattingId
+        from Chatting c
+        where c.chatroom.chatroomId = :chatroomId
+          and c.receiverId = :receiverId
+          and c.isRead = false
+          and c.deletedAt is null
+    """)
+    List<UUID> findUnreadChatIds(@Param("chatroomId") UUID chatroomId,
+                                 @Param("receiver") String receiverId);
+
+
+    // 채팅 읽음 처리 하기
+    @Modifying
+    @Query("""
+        update Chatting c
+        set c.isRead = true,
+            c.updatedAt = CURRENT_TIMESTAMP
+        where c.chattingId in :chatIds
+    """)
+    int markChatsAsRead(@Param("chatIds") List<UUID> chatIds);
 
 }

--- a/chat-service/src/main/java/com/javaauction/chatservice/presentation/advice/ChatErrorCode.java
+++ b/chat-service/src/main/java/com/javaauction/chatservice/presentation/advice/ChatErrorCode.java
@@ -13,7 +13,8 @@ public enum ChatErrorCode implements ResponseCode {
     CHAT_UNAUTH("ALERT003", "자신이 소속된 채팅방의 채팅만 접근 가능합니다.", HttpStatus.UNAUTHORIZED),
     CHAT_CANNOT_CREATE_WITH_SELF("CHAT004", "자신에게 채팅을 요청할 수 없습니다.", HttpStatus.BAD_REQUEST),
     CHAT_CANNOT_CREATE_DIFF_RECEIVER("CHAT005", "채팅방 소속이 아닌 유저에게 메시지를 전송할 수 없습니다.", HttpStatus.BAD_REQUEST),
-    CHAT_PRODUCT_FORBIDDEN("CHAT006", "채팅 요청을 보내는 상대가 상품 등록자와 일치하지 않습니다.", HttpStatus.FORBIDDEN);
+    CHAT_PRODUCT_FORBIDDEN("CHAT006", "채팅 요청을 보내는 상대가 상품 등록자와 일치하지 않습니다.", HttpStatus.FORBIDDEN),
+    CHAT_CHATROOM_ALREADY_EXIST("CHAT009", "해당 상품에 대한 채팅방이 이미 존재합니다.", HttpStatus.CONFLICT);
 
     private final String code;
     private final String message;

--- a/chat-service/src/main/java/com/javaauction/chatservice/presentation/controller/ChatControllerV1.java
+++ b/chat-service/src/main/java/com/javaauction/chatservice/presentation/controller/ChatControllerV1.java
@@ -86,41 +86,13 @@ public class ChatControllerV1 {
 
     // 채팅 읽음 처리
     @PostMapping("/{chatroomId}/chats/read")
-    public ResponseEntity<RepPostChatsReadDtoV1> readChats(@PathVariable UUID chatroomId) {
+    public ResponseEntity<ApiResponse<RepPostChatsReadDtoV1>> readChats(@PathVariable UUID chatroomId,
+                                                                        @RequestHeader("X-User-Username") String username) {
 
-        String receiverId = "dummyReceiver";
+        RepPostChatsReadDtoV1 postChatsReadDto = chatService.postChatsRead(chatroomId, username);
 
-        // 더미 메시지 리스트
-        List<RepPostChatsDtoV1> chatList = List.of(
-                new RepPostChatsDtoV1(UUID.randomUUID(), chatroomId, "sender1", receiverId, "안녕하세요", false, Instant.now()),
-                new RepPostChatsDtoV1(UUID.randomUUID(), chatroomId, "sender2", receiverId, "혹시 이 물건 아직 남아있나요?", false, Instant.now())
+        return ResponseEntity.ok(
+                ApiResponse.success(ChatSuccessCode.CHAT_FIND_SUCCESS, postChatsReadDto)
         );
-
-        // 읽음 처리 (더미 환경이므로 리스트 변환)
-        List<RepPostChatsDtoV1> readChats = chatList.stream()
-                .map(chat -> RepPostChatsDtoV1.builder()
-                        .chattingId(chat.getChattingId())
-                        .chatroomId(chat.getChatroomId())
-                        .senderId(chat.getSenderId())
-                        .receiverId(chat.getReceiverId())
-                        .content(chat.getContent())
-                        .isRead(true)
-                        .createdAt(chat.getCreatedAt())
-                        .build()
-                ).toList();
-
-        // 읽음 처리 & 읽은 chatId 추출
-        List<UUID> readChatIds = chatList.stream()
-                .map(chat -> chat.getChattingId())
-                .toList();
-
-        RepPostChatsReadDtoV1 response = RepPostChatsReadDtoV1.builder()
-                .chatroomId(chatroomId)
-                .receiverId(receiverId)
-                .readChatIds(readChatIds)
-                .message("읽지 않은 채팅 " + readChats.size() + "건이 읽음 처리 되었습니다.")
-                .build();
-
-        return ResponseEntity.ok(response);
     }
 }


### PR DESCRIPTION
## 📎 관련 이슈
- 관련 이슈 번호를 연결해주세요.  
  #2 

---

## 📢 개요(Summary)
채팅 읽음 처리 구현

---

## 🔧 변경 사항(Details)
- 채팅 읽음 처리 구현

---

## ✔️ 테스트 방법(Test)
- url의 채팅방 ID로 등록된 메시지 중 현재 로그인한 유저가 수신자이고, 읽음 여부가 false인 메시지를 모두 읽음 여부 true로 변경
<img width="558" height="660" alt="chatread1" src="https://github.com/user-attachments/assets/43e53f4f-6f4b-4e05-9c07-34746addef08" />
<img width="557" height="658" alt="chatread2" src="https://github.com/user-attachments/assets/50549fd3-a07c-4fca-8574-dd9c72823683" />

- 해당 채팅방에 소속되지 않은 유저가 읽음 처리 시도 시 예외 처리
<img width="563" height="574" alt="chatread3" src="https://github.com/user-attachments/assets/6420b6e7-06a0-4b80-beb7-43ece3b097e5" />


---
