### PR TITLE
Feat/#53 alert 에러코드 추가 및 수정

### DIFF
--- a/alert-service/src/main/java/com/javaauction/alertservice/application/service/AlertServiceV1.java
+++ b/alert-service/src/main/java/com/javaauction/alertservice/application/service/AlertServiceV1.java
@@ -75,7 +75,7 @@ public class AlertServiceV1 {
 
         // 권한 체크
         if (!hasPermission(userId, role, alert)) {
-            throw new BussinessException(AlertErrorCode.ALERT_UNAUTH);
+            throw new BussinessException(AlertErrorCode.ALERT_FORBIDDEN);
         }
 
         alert.alertRead();
@@ -89,6 +89,11 @@ public class AlertServiceV1 {
     @Transactional
     public RepDeleteAlertsDtoV1 deleteAlerts(ReqDeleteAlertsDtoV1 request, String userId, String role) {
 
+        // 요청이 비어있을때
+        if (request.getAlertIds() == null || request.getAlertIds().isEmpty()) {
+            throw new BussinessException(AlertErrorCode.ALERT_DELETE_IDS_EMPTY);
+        }
+
         // 삭제 대상 조회
         List<Alert> alerts = alertRepository.findAllByAlertIdInAndDeletedAtIsNull(request.getAlertIds());
 
@@ -100,7 +105,7 @@ public class AlertServiceV1 {
         // 권한 체크
         alerts.forEach(alert -> {
             if (!hasPermission(userId, role, alert)) {
-                throw new BussinessException(AlertErrorCode.ALERT_UNAUTH);
+                throw new BussinessException(AlertErrorCode.ALERT_FORBIDDEN);
             }
 
             alert.softDelete(Instant.now(), userId);
@@ -110,11 +115,6 @@ public class AlertServiceV1 {
         List<UUID> deletedIds = alerts.stream()
                 .map(Alert::getAlertId)
                 .toList();
-
-        // 메시지 생성
-        String message = deletedIds.isEmpty()
-                ? "삭제할 알림을 찾을 수 없습니다."
-                : deletedIds.size() + "건의 알림이 삭제되었습니다.";
 
         return RepDeleteAlertsDtoV1.of(deletedIds);
     }

--- a/alert-service/src/main/java/com/javaauction/alertservice/presentation/advice/AlertErrorCode.java
+++ b/alert-service/src/main/java/com/javaauction/alertservice/presentation/advice/AlertErrorCode.java
@@ -7,7 +7,9 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum AlertErrorCode implements ResponseCode {
     ALERT_NOT_FOUND("ALERT000", "해당 알림을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
-    ALERT_UNAUTH("ALERT001", "일반 회원은 자신의 알림만 접근 및 삭제 가능합니다.", HttpStatus.UNAUTHORIZED);
+    ALERT_FORBIDDEN("ALERT001", "일반 회원은 자신의 알림만 접근 가능합니다.", HttpStatus.FORBIDDEN),
+    ALERT_DELETE_IDS_EMPTY("ALERT002", "삭제할 알림이 없습니다.", HttpStatus.BAD_REQUEST);
+
 
     private final String code;
     private final String message;

--- a/alert-service/src/main/java/com/javaauction/alertservice/presentation/dto/response/RepDeleteAlertsDtoV1.java
+++ b/alert-service/src/main/java/com/javaauction/alertservice/presentation/dto/response/RepDeleteAlertsDtoV1.java
@@ -18,13 +18,9 @@ public class RepDeleteAlertsDtoV1 {
     private String message;
 
     public static RepDeleteAlertsDtoV1 of(List<UUID> alertIds) {
-        String message = alertIds.isEmpty()
-                ? "삭제할 알림을 찾을 수 없습니다."
-                : alertIds.size() + "건의 알림이 삭제되었습니다.";
-
         return RepDeleteAlertsDtoV1.builder()
                 .alertIds(alertIds)
-                .message(message)
+                .message(alertIds.size() + "건의 알림이 삭제되었습니다.")
                 .build();
     }
 }

--- a/chat-service/src/main/java/com/javaauction/chatservice/infrastructure/repository/ChattingRepositoryImpl.java
+++ b/chat-service/src/main/java/com/javaauction/chatservice/infrastructure/repository/ChattingRepositoryImpl.java
@@ -111,7 +111,7 @@ public class ChattingRepositoryImpl implements ChattingRepository {
             userCondition.or(qChatting.receiverId.eq(userId));
 
             booleanBuilder
-                    .and(qChatroom.deletedAt.isNull())
+                    .and(qChatting.deletedAt.isNull())
                     .and(userCondition);
         }
 


### PR DESCRIPTION
## 📎 관련 이슈
- 관련 이슈 번호를 연결해주세요.  
  #53 

---

## 📢 개요(Summary)
알림 서비스 에러코드 추가 및 수정

---

## 🔧 변경 사항(Details)
- 일반 회원의 알림 접근 권한 에러 unauthorize → forbidden 변경
- 알림 삭제 요청 ID 리스트 빈값일 시 예외 처리 추가

---

## ✔️ 테스트 방법(Test)
- 알림 삭제 예외처리 추가
<img width="1014" height="1143" alt="image" src="https://github.com/user-attachments/assets/a9108822-f4c4-4376-8165-d05bdea8f98a" />

- 알림 접근 권한 에러코드 수정
<img width="1046" height="1151" alt="image" src="https://github.com/user-attachments/assets/d6aca870-d321-441c-b1ee-b37f5ddb8e24" />

---
