### PR TITLE
#94 product image s3 업로드

### DIFF
--- a/product-service/build.gradle
+++ b/product-service/build.gradle
@@ -49,6 +49,8 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-validation-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	implementation 'software.amazon.awssdk:s3:2.25.25'
 }
 
 dependencyManagement {

--- a/product-service/src/main/java/com/springcloud/eureka/client/productservice/application/service/ProductService.java
+++ b/product-service/src/main/java/com/springcloud/eureka/client/productservice/application/service/ProductService.java
@@ -8,6 +8,7 @@ import com.springcloud.eureka.client.productservice.domain.error.ProductErrorCod
 import com.springcloud.eureka.client.productservice.infrastructure.client.UserServiceClient;
 import com.springcloud.eureka.client.productservice.infrastructure.repository.ProductCategoryRepository;
 import com.springcloud.eureka.client.productservice.infrastructure.repository.ProductRepository;
+import com.springcloud.eureka.client.productservice.infrastructure.s3.S3ImageUploader;
 import com.springcloud.eureka.client.productservice.presentation.dto.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -15,6 +16,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.time.Instant;
 import java.util.UUID;
@@ -27,15 +29,21 @@ public class ProductService {
     private final ProductRepository productRepository;
     private final ProductCategoryRepository categoryRepository;
     private final UserServiceClient userServiceClient;
+    private final S3ImageUploader s3ImageUploader;
 
     // 상품 생성
-    public RepProductDto createProduct(String username, ReqProductCreateDto request){
+    public RepProductDto createProduct(String username, ReqProductCreateDto request, MultipartFile file){
         // 카테고리 조회
         ProductCategory category = categoryRepository.findByName(request.getCategoryName())
                 .orElseThrow(() -> new BussinessException(ProductErrorCode.CATEGORY_NOT_FOUND));
 
-        Product product = request.toEntity(username);
-        product.changeCategory(category);
+        // 이미지 업로드
+        String imageUrl = null;
+        if (file != null && !file.isEmpty()) {
+            imageUrl = s3ImageUploader.uploadProductImage(file);
+        }
+
+        Product product = request.toEntity(username, imageUrl, category);
         product.setCreate(Instant.now(), username);
         Product saved = productRepository.save(product);
         return RepProductDto.from(saved);
@@ -81,7 +89,7 @@ public class ProductService {
     }
 
     // 상품 정보 수정
-    public RepProductDto updateProduct(UUID productId, ReqProductUpdateDto request, String username) {
+    public RepProductDto updateProduct(UUID productId, ReqProductUpdateDto request, MultipartFile file, String username) {
         Product product = productRepository.findById(productId)
                 .orElseThrow(() -> new BussinessException(ProductErrorCode.PRODUCT_NOT_FOUND));
 
@@ -91,8 +99,15 @@ public class ProductService {
         if (request.getDescription() != null) {
             product.changeDescription(request.getDescription());
         }
-        if (request.getImageUrl() != null) {
-            product.changeImageUrl(request.getImageUrl());
+        if (request.getCategoryName() != null) {
+            ProductCategory category = categoryRepository.findByName(request.getCategoryName())
+                    .orElseThrow(() -> new BussinessException(ProductErrorCode.CATEGORY_NOT_FOUND));
+            product.changeCategory(category);
+        }
+        // 새 이미지가 온 경우에만 교체
+        if (file != null && !file.isEmpty()) {
+            String newImageUrl = s3ImageUploader.uploadProductImage(file);
+            product.changeImageUrl(newImageUrl);
         }
 
         product.setUpdated(Instant.now(), username);

--- a/product-service/src/main/java/com/springcloud/eureka/client/productservice/infrastructure/s3/S3ImageUploader.java
+++ b/product-service/src/main/java/com/springcloud/eureka/client/productservice/infrastructure/s3/S3ImageUploader.java
@@ -1,0 +1,71 @@
+package com.springcloud.eureka.client.productservice.infrastructure.s3;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class S3ImageUploader {
+
+    @Value("${aws.s3.bucket}")
+    private String bucket;
+
+    @Value("${aws.s3.region}")
+    private String region;
+
+    @Value("${aws.s3.access-key}")
+    private String accessKey;
+
+    @Value("${aws.s3.secret-key}")
+    private String secretKey;
+
+    public String uploadProductImage(MultipartFile file) {
+        try {
+            S3Client s3 = S3Client.builder()
+                    .region(Region.of(region))
+                    .credentialsProvider(
+                            StaticCredentialsProvider.create(
+                                    AwsBasicCredentials.create(accessKey, secretKey)
+                            )
+                    )
+                    .build();
+
+            String ext = extractExtension(file.getOriginalFilename());
+            String key = "products/" + UUID.randomUUID() + ext;
+
+            PutObjectRequest put = PutObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(key)
+                    .contentType(file.getContentType())
+                    .build();
+
+            s3.putObject(put, software.amazon.awssdk.core.sync.RequestBody.fromInputStream(
+                    file.getInputStream(), file.getSize()
+            ));
+
+            String encodedKey = URLEncoder.encode(key, StandardCharsets.UTF_8);
+            return String.format("https://%s.s3.%s.amazonaws.com/%s", bucket, region, encodedKey);
+        } catch (IOException e) {
+            throw new RuntimeException("S3 업로드 실패", e);
+        }
+    }
+
+    private String extractExtension(String filename) {
+        if (filename == null || !filename.contains(".")) {
+            return "";
+        }
+        return filename.substring(filename.lastIndexOf("."));
+    }
+}

--- a/product-service/src/main/java/com/springcloud/eureka/client/productservice/presentation/controller/ProductController.java
+++ b/product-service/src/main/java/com/springcloud/eureka/client/productservice/presentation/controller/ProductController.java
@@ -5,10 +5,10 @@ import com.javaauction.global.presentation.response.ApiResponse;
 import com.springcloud.eureka.client.productservice.application.service.ProductService;
 import com.springcloud.eureka.client.productservice.domain.enums.ProductStatus;
 import com.springcloud.eureka.client.productservice.presentation.dto.*;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.Map;
 import java.util.UUID;
@@ -21,10 +21,12 @@ public class ProductController {
     private final ProductService productService;
 
     // 상품 등록
-    @PostMapping
-    public ResponseEntity<ApiResponse<RepProductDto>> createProduct(@Valid @RequestBody ReqProductCreateDto request, @RequestHeader("X-User-Username") String username) {
+    @PostMapping(consumes = "multipart/form-data")
+    public ResponseEntity<ApiResponse<RepProductDto>> createProduct(@RequestPart("request") ReqProductCreateDto request,
+                                                                    @RequestPart(value = "file", required = false) MultipartFile file,
+                                                                    @RequestHeader("X-User-Username") String username) {
 
-        RepProductDto response = productService.createProduct(username, request);
+        RepProductDto response = productService.createProduct(username, request, file);
 
         return ResponseEntity
                 .status(BaseSuccessCode.CREATED.getStatus())
@@ -65,13 +67,14 @@ public class ProductController {
     }
 
     // 상품 정보 수정
-    @PutMapping("/{productId}")
+    @PutMapping(value = "/{productId}", consumes = "multipart/form-data")
     public ResponseEntity<ApiResponse<RepProductDto>> updateProduct(
             @PathVariable UUID productId,
-            @RequestBody ReqProductUpdateDto request,
+            @RequestPart("request") ReqProductUpdateDto request,
+            @RequestPart(value = "file", required = false) MultipartFile file,
             @RequestHeader("X-User-Username") String username
     ) {
-        RepProductDto response = productService.updateProduct(productId, request, username);
+        RepProductDto response = productService.updateProduct(productId, request,file, username);
         return ResponseEntity.ok(ApiResponse.success(BaseSuccessCode.OK, response));
     }
 

--- a/product-service/src/main/java/com/springcloud/eureka/client/productservice/presentation/dto/ReqProductCreateDto.java
+++ b/product-service/src/main/java/com/springcloud/eureka/client/productservice/presentation/dto/ReqProductCreateDto.java
@@ -17,12 +17,11 @@ public class ReqProductCreateDto {
 
     private String description;
 
-    private  String imageUrl;
-
     @NotBlank
     private String categoryName;
 
-    public Product toEntity(String userId) {
-        return Product.create(userId, name, description, imageUrl, null);
+    // imageUrl은 Service에서 세팅
+    public Product toEntity(String userId, String imageUrl, ProductCategory category) {
+        return Product.create(userId, name, description, imageUrl, category);
     }
 }

--- a/product-service/src/main/java/com/springcloud/eureka/client/productservice/presentation/dto/ReqProductUpdateDto.java
+++ b/product-service/src/main/java/com/springcloud/eureka/client/productservice/presentation/dto/ReqProductUpdateDto.java
@@ -10,6 +10,5 @@ import lombok.Setter;
 public class ReqProductUpdateDto {
     private String name;
     private String description;
-    private String imageUrl;
     private String categoryName;
 }

--- a/product-service/src/main/resources/application.yml
+++ b/product-service/src/main/resources/application.yml
@@ -24,3 +24,10 @@ eureka:
       defaultZone: http://localhost:19090/eureka/
     register-with-eureka: true
     fetch-registry: true
+
+aws:
+  s3:
+    bucket: java-auction-bucket
+    region: ap-northeast-2
+    access-key: ${AWS_ACCESS_KEY}
+    secret-key: ${AWS_SECRET_KEY}


### PR DESCRIPTION
## 📎 관련 이슈
- 관련 이슈 번호를 연결해주세요.  
  Closes #94

---

## 📢 개요 (Summary)
- 상품 서비스에 S3 기반 이미지 업로드 기능을 추가
- 상품 수정 시에도 이미지를 교체할 수 있도록 API와 서비스 로직을 확장
- 키는 환경변수처리

---

## 🔧 변경 사항 (Details)

- 상품 등록 API를 multipart/form-data 형식으로 변경하여 JSON(`request`)과 이미지 파일(`file`)을 동시에 처리하도록 컨트롤러와 DTO를 수정
- S3ImageUploader를 통해 상품 생성·수정 시 이미지 파일을 S3 버킷에 업로드하고, 반환된 URL을 `Product` 엔티티의 `imageUrl` 필드에 저장하는 로직을 구현
- 상품 정보 수정 API에 이미지 업로드를 지원하도록 엔드포인트 시그니처를 @RequestPart기반으로 변경하고, 이름/설명/카테고리/이미지를 선택적으로 갱신할 수 있도록 서비스 로직을 분리


---

## ✔️ 테스트 방법(Test)
해당 PR을 검증하기 위해 실행해야 할 테스트 방법을 작성해주세요.

<img width="1408" height="1558" alt="image" src="https://github.com/user-attachments/assets/50c54b5a-41b0-43fd-8179-792663e64fa1" />
<img width="1412" height="1532" alt="image" src="https://github.com/user-attachments/assets/36fdb91c-311d-409f-871d-710d97156b4f" />
<img width="1096" height="804" alt="image" src="https://github.com/user-attachments/assets/6f8bfb02-b793-4050-952a-55be2941daab" />


---
