### PR TITLE
Feat/#53 alert create 이벤트 처리

### DIFF
--- a/alert-service/build.gradle
+++ b/alert-service/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
     implementation 'com.github.JavaAuction:common-repo:0.0.1'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+    implementation 'org.springframework.kafka:spring-kafka'
 
     implementation "com.querydsl:querydsl-jpa:${querydslVersion}:jakarta"
     annotationProcessor "com.querydsl:querydsl-apt:${querydslVersion}:jakarta"

--- a/alert-service/src/main/java/com/javaauction/alertservice/AlertServiceApplication.java
+++ b/alert-service/src/main/java/com/javaauction/alertservice/AlertServiceApplication.java
@@ -4,7 +4,9 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.scheduling.annotation.EnableAsync;
 
+@EnableAsync
 @EnableFeignClients
 @EnableDiscoveryClient
 @SpringBootApplication

--- a/alert-service/src/main/java/com/javaauction/alertservice/AlertServiceApplication.java
+++ b/alert-service/src/main/java/com/javaauction/alertservice/AlertServiceApplication.java
@@ -8,7 +8,6 @@ import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.scheduling.annotation.EnableAsync;
 
 @EnableAsync
-@EnableKafka
 @EnableFeignClients
 @EnableDiscoveryClient
 @SpringBootApplication

--- a/alert-service/src/main/java/com/javaauction/alertservice/AlertServiceApplication.java
+++ b/alert-service/src/main/java/com/javaauction/alertservice/AlertServiceApplication.java
@@ -4,9 +4,11 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.scheduling.annotation.EnableAsync;
 
 @EnableAsync
+@EnableKafka
 @EnableFeignClients
 @EnableDiscoveryClient
 @SpringBootApplication

--- a/alert-service/src/main/java/com/javaauction/alertservice/application/event/AlertCreatedEvent.java
+++ b/alert-service/src/main/java/com/javaauction/alertservice/application/event/AlertCreatedEvent.java
@@ -1,0 +1,11 @@
+package com.javaauction.alertservice.application.event;
+
+import com.javaauction.alertservice.domain.entity.Alert;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class AlertCreatedEvent {
+    private final Alert alert;
+}

--- a/alert-service/src/main/java/com/javaauction/alertservice/application/event/AlertEventListener.java
+++ b/alert-service/src/main/java/com/javaauction/alertservice/application/event/AlertEventListener.java
@@ -1,0 +1,63 @@
+package com.javaauction.alertservice.application.event;
+
+import com.javaauction.alertservice.application.client.SlackClientV1;
+import com.javaauction.alertservice.application.client.UserClientV1;
+import com.javaauction.alertservice.domain.entity.Alert;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AlertEventListener {
+
+    private final SlackClientV1 slackClient;
+    private final UserClientV1 userClient;
+
+    @Async   // 비동기
+    @EventListener
+    public void onAlertCreated(AlertCreatedEvent event) {
+        Alert alert = event.getAlert();
+        sendSlack(alert);
+    }
+
+    // 슬랙 발송
+    private void sendSlack(Alert alert) {
+        try {
+            var repUserDto = userClient.getUser(alert.getUserId());
+
+            if (repUserDto.getSlackId() == null || repUserDto.getSlackId().isBlank()) {
+                return;
+            }
+
+            Map<String, Object> openResp = slackClient.openConversation(
+                    "Bearer " + System.getenv("SLACK_BOT_TOKEN"),
+                    Map.of("users", repUserDto.getSlackId())
+            );
+
+            if (openResp != null && Boolean.TRUE.equals(openResp.get("ok"))) {
+                Map<String, Object> channelMap = (Map<String, Object>) openResp.get("channel");
+                String channelId = (String) channelMap.get("id");
+
+                if (channelId != null && !channelId.isBlank()) {
+                    Map<String, Object> msgResp = slackClient.postMessage(
+                            "Bearer " + System.getenv("SLACK_BOT_TOKEN"),
+                            Map.of("channel", channelId, "text", alert.getContent())
+                    );
+
+                    if (msgResp == null || !Boolean.TRUE.equals(msgResp.get("ok"))) {
+                        log.warn("Slack 메시지 전송 실패: {}", msgResp);
+                    }
+                }
+            }
+
+        } catch (Exception e) {
+            log.error("Slack 메시지 발송 중 예외 발생", e);
+        }
+    }
+}

--- a/alert-service/src/main/java/com/javaauction/alertservice/application/event/AlertKafkaConsumer.java
+++ b/alert-service/src/main/java/com/javaauction/alertservice/application/event/AlertKafkaConsumer.java
@@ -14,10 +14,17 @@ public class AlertKafkaConsumer {
 
     private final AlertServiceV1 alertService;
 
-    @KafkaListener(topics = "auction-alert-topic", groupId = "alert-service-group") // 임시 topics 설정
+    @KafkaListener(topics = "auction-alert-topic", groupId = "alert-group",
+                   containerFactory = "kafkaListenerContainerFactory")
     public void handleAlertMessage(ReqPostInternalAlertsDtoV1 message) {
+        log.info("카프카 메시지 수신: {}", message);
 
-        // 알림 생성
-        alertService.postInternalAlerts(message);
+        try {
+            alertService.postInternalAlerts(message);
+            log.info("알림 저장 성공: {}", message.getUserId());
+
+        } catch (Exception e) {
+            log.error("알림 저장 실패: {}", message, e);
+        }
     }
 }

--- a/alert-service/src/main/java/com/javaauction/alertservice/application/event/AlertKafkaConsumer.java
+++ b/alert-service/src/main/java/com/javaauction/alertservice/application/event/AlertKafkaConsumer.java
@@ -1,0 +1,23 @@
+package com.javaauction.alertservice.application.event;
+
+import com.javaauction.alertservice.application.service.AlertServiceV1;
+import com.javaauction.alertservice.presentation.dto.request.ReqPostInternalAlertsDtoV1;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AlertKafkaConsumer {
+
+    private final AlertServiceV1 alertService;
+
+    @KafkaListener(topics = "auction-alert-topic", groupId = "alert-service-group") // 임시 topics 설정
+    public void handleAlertMessage(ReqPostInternalAlertsDtoV1 message) {
+
+        // 알림 생성
+        alertService.postInternalAlerts(message);
+    }
+}

--- a/alert-service/src/main/java/com/javaauction/alertservice/application/service/AlertServiceV1.java
+++ b/alert-service/src/main/java/com/javaauction/alertservice/application/service/AlertServiceV1.java
@@ -2,6 +2,7 @@ package com.javaauction.alertservice.application.service;
 
 import com.javaauction.alertservice.application.client.SlackClientV1;
 import com.javaauction.alertservice.application.client.UserClientV1;
+import com.javaauction.alertservice.application.event.AlertCreatedEvent;
 import com.javaauction.alertservice.domain.entity.Alert;
 import com.javaauction.alertservice.infrastructure.repository.AlertJpaRepository;
 import com.javaauction.alertservice.presentation.advice.AlertErrorCode;
@@ -13,6 +14,7 @@ import com.javaauction.global.presentation.exception.BussinessException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -30,8 +32,7 @@ import java.util.UUID;
 @Transactional(readOnly = true)
 public class AlertServiceV1 {
     private final AlertJpaRepository alertRepository;
-    private final UserClientV1 userClient;
-    private final SlackClientV1 slackClient;
+    private final ApplicationEventPublisher publisher;
 
     @Value("${slack.bot.token}")
     private String botToken;
@@ -49,8 +50,8 @@ public class AlertServiceV1 {
         );
         alertRepository.save(alert);
 
-        // 2. Slack 발송
-        sendSlack(alert.getUserId(), reqDto.getContent());
+        // 2. Slack 발송 이벤트 발행
+        publisher.publishEvent(new AlertCreatedEvent(alert));
 
         // 3. 응답 반환
         return RepPostInternalAlertsDtoV1.of(alert);
@@ -117,40 +118,6 @@ public class AlertServiceV1 {
                 .toList();
 
         return RepDeleteAlertsDtoV1.of(deletedIds);
-    }
-
-    // 슬랙 메시지 전송
-    private void sendSlack(String userId, String content) {
-        try {
-            RepGetInternalUsersDtoV1 repUserDto = userClient.getUser(userId);
-
-            if (repUserDto.getSlackId() == null || repUserDto.getSlackId().isBlank()) {
-                return;
-            }
-
-            Map<String, Object> openResp = slackClient.openConversation(
-                    "Bearer " + botToken,
-                    Map.of("users", repUserDto.getSlackId())
-            );
-
-            if (openResp != null && Boolean.TRUE.equals(openResp.get("ok"))) {
-                Map<String, Object> channelMap = (Map<String, Object>) openResp.get("channel");
-                String channelId = (String) channelMap.get("id");
-
-                if (channelId != null && !channelId.isBlank()) {
-                    Map<String, Object> msgResp = slackClient.postMessage(
-                            "Bearer " + botToken,
-                            Map.of("channel", channelId, "text", content)
-                    );
-
-                    if (msgResp == null || !Boolean.TRUE.equals(msgResp.get("ok"))) {
-                        log.warn("Slack 메시지 전송 실패: {}", msgResp);
-                    }
-                }
-            }
-        } catch (Exception e) {
-            log.error("Slack 메시지 발송 중 예외 발생", e);
-        }
     }
 
     // 권한 체크

--- a/alert-service/src/main/java/com/javaauction/alertservice/domain/entity/Alert.java
+++ b/alert-service/src/main/java/com/javaauction/alertservice/domain/entity/Alert.java
@@ -10,7 +10,15 @@ import java.util.UUID;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "p_alert")
+@Table(
+        name = "p_alert",
+        indexes = {
+                @Index(
+                        name = "idx_alert_userid_isread_createdat",
+                        columnList = "user_id, is_read, created_at DESC"
+                )
+        }
+)
 public class Alert extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)

--- a/alert-service/src/main/java/com/javaauction/alertservice/infrastructure/config/KafkaConsumerConfig.java
+++ b/alert-service/src/main/java/com/javaauction/alertservice/infrastructure/config/KafkaConsumerConfig.java
@@ -1,0 +1,48 @@
+package com.javaauction.alertservice.infrastructure.config;
+
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.javaauction.alertservice.presentation.dto.request.ReqPostInternalAlertsDtoV1;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import tools.jackson.databind.deser.jdk.StringDeserializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+@EnableKafka
+public class KafkaConsumerConfig {
+
+    @Bean
+    public ConsumerFactory<String, ReqPostInternalAlertsDtoV1> consumerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, "alert-group");
+
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
+                org.apache.kafka.common.serialization.StringDeserializer.class);
+
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
+                org.springframework.kafka.support.serializer.JsonDeserializer.class);
+
+        props.put("spring.json.trusted.packages", "*");
+        props.put("spring.json.use.type.headers", false);
+        props.put("spring.json.value.default.type",
+                "com.javaauction.alertservice.presentation.dto.request.ReqPostInternalAlertsDtoV1");
+
+        return new DefaultKafkaConsumerFactory<>(props);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, ReqPostInternalAlertsDtoV1> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, ReqPostInternalAlertsDtoV1> factory =
+                new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+        return factory;
+    }
+}

--- a/alert-service/src/main/java/com/javaauction/alertservice/infrastructure/repository/AlertRepository.java
+++ b/alert-service/src/main/java/com/javaauction/alertservice/infrastructure/repository/AlertRepository.java
@@ -1,6 +1,5 @@
 package com.javaauction.alertservice.infrastructure.repository;
 
-import com.javaauction.alertservice.domain.entity.Alert;
 import com.javaauction.alertservice.presentation.dto.common.SearchParam;
 import com.javaauction.alertservice.presentation.dto.response.RepGetAlertsDtoV1;
 import org.springframework.data.domain.Page;

--- a/alert-service/src/main/java/com/javaauction/alertservice/infrastructure/repository/AlertRepositoryImpl.java
+++ b/alert-service/src/main/java/com/javaauction/alertservice/infrastructure/repository/AlertRepositoryImpl.java
@@ -18,7 +18,6 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
-import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.OrderSpecifier;
 
 import java.util.*;

--- a/alert-service/src/main/resources/application.yml
+++ b/alert-service/src/main/resources/application.yml
@@ -20,6 +20,15 @@ spring:
         format_sql: true
         dialect: org.hibernate.dialect.PostgreSQLDialect
 
+  kafka:
+    bootstrap-servers: localhost:9092
+    consumer:
+      group-id: alert-service-group
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      properties:
+        spring.json.trusted.packages: "*"
+
 eureka:
   client:
     register-with-eureka: true

--- a/alert-service/src/main/resources/application.yml
+++ b/alert-service/src/main/resources/application.yml
@@ -21,13 +21,16 @@ spring:
         dialect: org.hibernate.dialect.PostgreSQLDialect
 
   kafka:
-    bootstrap-servers: localhost:9092
     consumer:
-      group-id: alert-service-group
+      bootstrap-servers: localhost:9092
+      group-id: alert-group
+      auto-offset-reset: earliest
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
       properties:
         spring.json.trusted.packages: "*"
+        spring.json.value.default.type: com.javaauction.alertservice.presentation.dto.request.ReqPostInternalAlertsDtoV1
+
 
 eureka:
   client:


### PR DESCRIPTION
## 📎 관련 이슈
- 관련 이슈 번호를 연결해주세요.  
  #53 

---

## 📢 개요(Summary)
알림 생성 이벤트 처리

---

## 🔧 변경 사항(Details)
- 알림 생성 후 슬랙 메시지 발송 비동기로 변경
- 알림 리스트 조회 인덱스 적용
- 알림 생성 카프카 메시지 받아서 처리하는 구조로 변경

---

## ✔️ 테스트 방법(Test)
- 알림 생성 시 슬랙 메시지 발송 비동기 + 이벤트 발행으로 변경 전후 성능
<img width="715" height="171" alt="알림생성_이벤트처리전" src="https://github.com/user-attachments/assets/c49d6811-08d8-4fc9-9463-38a461d23bb7" />
<img width="720" height="172" alt="알림생성_이벤트처리후" src="https://github.com/user-attachments/assets/91e1b4bb-96ce-48bc-96f1-a703bcfcd175" />

- 알림 리스트 조회 인덱스 적용 전후 성능
<img width="714" height="173" alt="알림조회_인덱스적용전" src="https://github.com/user-attachments/assets/4984dad4-eaae-45fb-b47e-3974aa788c41" />
<img width="718" height="172" alt="알림조회_인덱스적용후" src="https://github.com/user-attachments/assets/d35158c0-b796-4ef8-b5b6-644eca84a672" />

- 경매에서 보낸 카프카 메시지를 구독하여 처리
<img width="849" height="382" alt="알림_카프카연결" src="https://github.com/user-attachments/assets/db05c746-5a12-4ccb-bc95-6420119bcba2" />

---
