### PR TITLE
Feat/#85 chat get refact

### DIFF
--- a/chat-service/build.gradle
+++ b/chat-service/build.gradle
@@ -45,6 +45,9 @@ dependencies {
     annotationProcessor "jakarta.persistence:jakarta.persistence-api:3.2.0"
     implementation 'org.jetbrains:annotations:24.1.0'
 
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'org.postgresql:postgresql'
     annotationProcessor 'org.projectlombok:lombok'

--- a/chat-service/src/main/java/com/javaauction/chatservice/application/event/sse/SseEmitterRepository.java
+++ b/chat-service/src/main/java/com/javaauction/chatservice/application/event/sse/SseEmitterRepository.java
@@ -22,11 +22,11 @@ public class SseEmitterRepository {
         return emitter;
     }
 
-    public void delete(UUID chatroomId, String userId, String role) {
+    public void delete(UUID chatroomId, String userId) {
         Map<String, SseEmitter> map = emitterMap.get(chatroomId);
         if (map != null) {
             map.remove(userId);
-            log.info("[SSE] emitter removed: {} (role={})", userId, role);
+            log.info("[SSE] emitter removed: {}", userId);
         }
     }
 

--- a/chat-service/src/main/java/com/javaauction/chatservice/application/event/sse/SseEmitterRepository.java
+++ b/chat-service/src/main/java/com/javaauction/chatservice/application/event/sse/SseEmitterRepository.java
@@ -1,4 +1,4 @@
-package com.javaauction.chatservice.infrastructure.repository;
+package com.javaauction.chatservice.application.event.sse;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;

--- a/chat-service/src/main/java/com/javaauction/chatservice/application/event/sse/SseEmitterService.java
+++ b/chat-service/src/main/java/com/javaauction/chatservice/application/event/sse/SseEmitterService.java
@@ -15,88 +15,47 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class SseEmitterService {
 
     private final SseEmitterRepository emitterRepository;
-    private final ChatroomJpaRepository chatroomRepository;
     private final ObjectMapper objectMapper;
 
-    private static final long TIMEOUT = 1000L * 60 * 60; // 1시간
+    private static final long TIMEOUT = 1000L * 60 * 60;
 
-    public SseEmitter subscribe(UUID chatroomId, String userId, String role) {
-
-        // 권한 체크
-        validateAccess(chatroomId, userId, role);
+    public SseEmitter subscribe(UUID chatroomId, String userId) {
 
         SseEmitter emitter = new SseEmitter(TIMEOUT);
-
         emitterRepository.save(chatroomId, userId, emitter);
 
-        emitter.onCompletion(() -> {
-            log.info("[SSE] onCompletion: {}", userId);
-            emitterRepository.delete(chatroomId, userId, role);
-        });
+        emitter.onCompletion(() -> emitterRepository.delete(chatroomId, userId));
+        emitter.onTimeout(() -> emitterRepository.delete(chatroomId, userId));
+        emitter.onError(e -> emitterRepository.delete(chatroomId, userId));
 
-        emitter.onTimeout(() -> {
-            log.info("[SSE] onTimeout: {}", userId);
-            emitterRepository.delete(chatroomId, userId, role);
-        });
-
-        emitter.onError(e -> {
-            log.error("[SSE] onError: {}", userId);
-            emitterRepository.delete(chatroomId, userId, role);
-        });
-
-        // 초기 연결 이벤트
         try {
-            emitter.send(
-                    SseEmitter.event()
-                            .name("connect")
-                            .data("connected")
-            );
+            emitter.send(SseEmitter.event().name("connect").data("connected"));
         } catch (Exception ignored) {}
 
         return emitter;
     }
 
-
-    private void validateAccess(UUID chatroomId, String userId, String role) {
-
-        // ADMIN은 모든 채팅방 접근 가능
-        if ("ADMIN".equals(role)) return;
-
-        Chatroom chatroom = chatroomRepository.findById(chatroomId)
-                .orElseThrow(() -> new BussinessException(ChatErrorCode.CHAT_CHATROOM_NOT_FOUND));
-
-        boolean isMember =
-                chatroom.getChatroomHost().equals(userId) ||
-                        chatroom.getChatroomGuest().equals(userId);
-
-        if (!isMember) {
-            throw new BussinessException(ChatErrorCode.CHATROOM_ACCESS_DENIED);
-        }
-    }
-
-
     public void sendChatMessage(UUID chatroomId, Chatting chatData) {
-
-        String json;
         try {
-            Map<String, Object> payload = new HashMap<>();
-            payload.put("senderId", chatData.getSenderId());
-            payload.put("content", chatData.getContent());
-            payload.put("createdAt", chatData.getCreatedAt());
+            Map<String, Object> payload = Map.of(
+                    "senderId", chatData.getSenderId(),
+                    "content", chatData.getContent(),
+                    "createdAt", chatData.getCreatedAt()
+            );
 
-            json = objectMapper.writeValueAsString(payload);
+            emitterRepository.send(chatroomId,
+                    objectMapper.writeValueAsString(payload));
 
         } catch (Exception e) {
-            log.error("[SSE] JSON 직렬화 실패", e);
-            return;
+            log.error("[SSE] send error", e);
         }
-
-        emitterRepository.send(chatroomId, json);
     }
 }
+
+

--- a/chat-service/src/main/java/com/javaauction/chatservice/application/event/sse/SseEmitterService.java
+++ b/chat-service/src/main/java/com/javaauction/chatservice/application/event/sse/SseEmitterService.java
@@ -1,19 +1,16 @@
-package com.javaauction.chatservice.application.service;
+package com.javaauction.chatservice.application.event.sse;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.javaauction.chatservice.domain.entity.Chatroom;
 import com.javaauction.chatservice.domain.entity.Chatting;
 import com.javaauction.chatservice.infrastructure.repository.ChatroomJpaRepository;
-import com.javaauction.chatservice.infrastructure.repository.SseEmitterRepository;
 import com.javaauction.chatservice.presentation.advice.ChatErrorCode;
 import com.javaauction.global.presentation.exception.BussinessException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
-import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -21,7 +18,7 @@ import java.util.UUID;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class SseEmitterServiceV1 {
+public class SseEmitterService {
 
     private final SseEmitterRepository emitterRepository;
     private final ChatroomJpaRepository chatroomRepository;

--- a/chat-service/src/main/java/com/javaauction/chatservice/application/service/ChatServiceV1.java
+++ b/chat-service/src/main/java/com/javaauction/chatservice/application/service/ChatServiceV1.java
@@ -1,6 +1,7 @@
 package com.javaauction.chatservice.application.service;
 
 import com.javaauction.chatservice.application.client.ProductClientV1;
+import com.javaauction.chatservice.application.event.sse.SseEmitterService;
 import com.javaauction.chatservice.domain.entity.Chatroom;
 import com.javaauction.chatservice.domain.entity.Chatting;
 import com.javaauction.chatservice.infrastructure.repository.ChatroomJpaRepository;
@@ -18,6 +19,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 
@@ -28,7 +30,7 @@ public class ChatServiceV1 {
     private final ChatroomJpaRepository chatroomRepository;
     private final ChattingJpaRepository chattingRepository;
     private final ProductClientV1 productClient;
-    private final SseEmitterServiceV1 sseEmitterService;
+    private final SseEmitterService sseEmitterService;
 
     // 채팅방 생성
     @Transactional
@@ -161,4 +163,66 @@ public class ChatServiceV1 {
                 .message(unreadChatIds.size() + "건의 읽지 않은 채팅이 읽음 처리 되었습니다.")
                 .build();
     }
+
+    // 커서 기반 채팅 리스트 조회
+    @Transactional(readOnly = true)
+    public RepGetChatsCursorDtoV1 getChatsByCursor(
+            UUID chatroomId,
+            UUID cursorChattingId,
+            String userId,
+            String role
+    ) {
+        // 채팅방 존재 확인
+        Chatroom chatroom = chatroomRepository.findByChatroomIdAndDeletedAtIsNull(chatroomId)
+                .orElseThrow(() -> new BussinessException(ChatErrorCode.CHAT_CHATROOM_NOT_FOUND));
+
+        // 권한 체크
+        if (role.equals("USER") &&
+                !(chatroom.getChatroomHost().equals(userId)
+                        || chatroom.getChatroomGuest().equals(userId))) {
+            throw new BussinessException(ChatErrorCode.CHATROOM_ACCESS_DENIED);
+        }
+
+        int pageSize = 100;
+
+        // 커서 chattingId로 createdAt 조회
+        Instant cursorCreatedAt = null;
+        if (cursorChattingId != null) {
+            Chatting cursorChatting = chattingRepository.findById(cursorChattingId)
+                    .orElseThrow(() -> new BussinessException(ChatErrorCode.CHAT_CHATTING_NOT_FOUND));
+            cursorCreatedAt = cursorChatting.getCreatedAt();
+        }
+
+        List<RepGetChatsDtoV1> chats =
+                chattingRepository.findChatsByCursor(
+                        chatroomId,
+                        cursorChattingId,
+                        cursorCreatedAt,
+                        pageSize + 1, // hasNext 판별용 : 100 이하면 다음 페이지 없음
+                        userId,
+                        role
+                );
+
+        boolean hasNext = chats.size() > pageSize;
+
+        if (hasNext) {
+            chats.remove(chats.size() - 1);
+        }
+
+        // nextCursor 생성
+        RepGetChatsCursorDtoV1.Cursor nextCursor = null;
+        if (!chats.isEmpty()) {
+            RepGetChatsDtoV1 last = chats.get(chats.size() - 1);
+            nextCursor = RepGetChatsCursorDtoV1.Cursor.builder()
+                    .chattingId(last.getChattingId())
+                    .build();
+        }
+
+        return RepGetChatsCursorDtoV1.builder()
+                .chats(chats)
+                .nextCursor(nextCursor)
+                .hasNext(hasNext)
+                .build();
+    }
+
 }

--- a/chat-service/src/main/java/com/javaauction/chatservice/application/service/ChatServiceV1.java
+++ b/chat-service/src/main/java/com/javaauction/chatservice/application/service/ChatServiceV1.java
@@ -110,6 +110,7 @@ public class ChatServiceV1 {
     }
 
     // 채팅방 리스트 조회
+    @Transactional(readOnly = true)
     public Page<RepGetChatroomsDtoV1> getChatrooms(ChatroomSearchParam chatroomSearchParam, Pageable pageable, String userId, String role) {
 
         Page<RepGetChatroomsDtoV1> page = chatroomRepository.findChatroomPage(chatroomSearchParam, pageable, userId, role);
@@ -118,6 +119,7 @@ public class ChatServiceV1 {
     }
 
     // 채팅 리스트 조회
+    @Transactional(readOnly = true)
     public Page<RepGetChatsDtoV1> getChats(UUID chatroomId, ChattingSearchParam chattingSearchParam, Pageable pageable, String userId, String role) {
         // 채팅방 존재 여부 확인
         Chatroom chatroom = chatroomRepository.findByChatroomIdAndDeletedAtIsNull(chatroomId)

--- a/chat-service/src/main/java/com/javaauction/chatservice/application/service/ChatServiceV1.java
+++ b/chat-service/src/main/java/com/javaauction/chatservice/application/service/ChatServiceV1.java
@@ -18,6 +18,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.time.Instant;
 import java.util.List;
@@ -162,6 +163,23 @@ public class ChatServiceV1 {
                 .readChatIds(unreadChatIds)
                 .message(unreadChatIds.size() + "건의 읽지 않은 채팅이 읽음 처리 되었습니다.")
                 .build();
+    }
+
+    // SSE 구독
+    @Transactional(readOnly = true)
+    public SseEmitter subscribeChatroom(UUID chatroomId, String userId, String role) {
+
+        Chatroom chatroom = chatroomRepository.findByChatroomIdAndDeletedAtIsNull(chatroomId)
+                .orElseThrow(() -> new BussinessException(ChatErrorCode.CHAT_CHATROOM_NOT_FOUND));
+
+        // 권한 체크
+        if ("USER".equals(role) &&
+                !(chatroom.getChatroomHost().equals(userId)
+                        || chatroom.getChatroomGuest().equals(userId))) {
+            throw new BussinessException(ChatErrorCode.CHATROOM_ACCESS_DENIED);
+        }
+
+        return sseEmitterService.subscribe(chatroomId, userId);
     }
 
     // 커서 기반 채팅 리스트 조회

--- a/chat-service/src/main/java/com/javaauction/chatservice/domain/entity/Chatroom.java
+++ b/chat-service/src/main/java/com/javaauction/chatservice/domain/entity/Chatroom.java
@@ -11,7 +11,20 @@ import java.util.UUID;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "p_chatroom")
+@Table(
+        name = "p_chatroom",
+        indexes = {
+                // USER 권한: 내가 속한 채팅방 조회 (OR 조건 대비)
+                @Index(name = "idx_chatroom_host_deleted", columnList = "chatroom_host, deleted_at"),
+                @Index(name = "idx_chatroom_guest_deleted", columnList = "chatroom_guest, deleted_at"),
+
+                // 상품 기준 조회
+                @Index(name = "idx_chatroom_product", columnList = "product_id"),
+
+                // 기본 정렬
+                @Index(name = "idx_chatroom_created_at", columnList = "created_at DESC")
+        }
+)
 public class Chatroom extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)

--- a/chat-service/src/main/java/com/javaauction/chatservice/domain/entity/Chatting.java
+++ b/chat-service/src/main/java/com/javaauction/chatservice/domain/entity/Chatting.java
@@ -17,7 +17,7 @@ import java.util.UUID;
 
                 // USER 권한 조회 최적화 (OR 조건 대비)
                 @Index(name = "idx_chatting_room_sender_created", columnList = "chatroom_id, sender_id, created_at DESC"),
-                @Index(name = "idx_chatting_room_receiver_created", columnList = "chatroom_id, receiver_id, created_at DESC")
+                @Index(name = "idx_chatting_room_receiver_created", columnList = "chatroom_id, receiver_id, created_at DESC"),
         }
 )
 public class Chatting extends BaseEntity {

--- a/chat-service/src/main/java/com/javaauction/chatservice/domain/entity/Chatting.java
+++ b/chat-service/src/main/java/com/javaauction/chatservice/domain/entity/Chatting.java
@@ -9,7 +9,17 @@ import java.util.UUID;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "p_chatting")
+@Table(
+        name = "p_chatting",
+        indexes = {
+                // chatroom별 최신 채팅 조회 (서브쿼리 + ORDER BY)
+                @Index(name = "idx_chatting_room_created_desc", columnList = "chatroom_id, created_at DESC"),
+
+                // USER 권한 조회 최적화 (OR 조건 대비)
+                @Index(name = "idx_chatting_room_sender_created", columnList = "chatroom_id, sender_id, created_at DESC"),
+                @Index(name = "idx_chatting_room_receiver_created", columnList = "chatroom_id, receiver_id, created_at DESC")
+        }
+)
 public class Chatting extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)

--- a/chat-service/src/main/java/com/javaauction/chatservice/infrastructure/repository/ChattingRepository.java
+++ b/chat-service/src/main/java/com/javaauction/chatservice/infrastructure/repository/ChattingRepository.java
@@ -5,9 +5,21 @@ import com.javaauction.chatservice.presentation.dto.response.RepGetChatsDtoV1;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.time.Instant;
+import java.util.List;
 import java.util.UUID;
 
 public interface ChattingRepository {
     // 검색 조건, 페이지 정보 기반 채팅 목록 동적 조회
     Page<RepGetChatsDtoV1> findChattingPage(UUID chatroomId, ChattingSearchParam chattingSearchParam, Pageable pageable, String userId, String role);
+
+    // 커서 기반 채팅 목록 조회
+    List<RepGetChatsDtoV1> findChatsByCursor(
+            UUID chatroomId,
+            UUID cursorChattingId,
+            Instant cursorCreatedAt,
+            int size,
+            String userId,
+            String role
+    );
 }

--- a/chat-service/src/main/java/com/javaauction/chatservice/infrastructure/repository/ChattingRepositoryImpl.java
+++ b/chat-service/src/main/java/com/javaauction/chatservice/infrastructure/repository/ChattingRepositoryImpl.java
@@ -21,6 +21,7 @@ import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
@@ -36,7 +37,6 @@ public class ChattingRepositoryImpl implements ChattingRepository {
             "senderId", "receiverId", "isRead", "createdAt"
     );
 
-    QChatroom qChatroom = QChatroom.chatroom;
     QChatting qChatting = QChatting.chatting;
 
     // 채팅 조회
@@ -81,6 +81,46 @@ public class ChattingRepositoryImpl implements ChattingRepository {
         return PageableExecutionUtils.getPage(results, adjustedPageable, cnt::fetchOne);
 
     }
+
+    // 커서 기반 채팅 조회
+    @Override
+    public List<RepGetChatsDtoV1> findChatsByCursor(
+            UUID chatroomId,
+            UUID cursorChattingId,
+            Instant cursorCreatedAt,
+            int size,
+            String userId,
+            String role
+    ) {
+
+        BooleanBuilder where = new BooleanBuilder();
+        where.and(qChatting.chatroom.chatroomId.eq(chatroomId));
+
+        if ("USER".equals(role)) {
+            where.and(
+                    qChatting.senderId.eq(userId)
+                            .or(qChatting.receiverId.eq(userId))
+            ).and(qChatting.deletedAt.isNull());
+        }
+
+        // 커서 조건
+        if (cursorChattingId != null) {
+            where.and(
+                    qChatting.createdAt.lt(cursorCreatedAt)
+            );
+        }
+
+        return queryFactory
+                .select(getChattingProjection())
+                .from(qChatting)
+                .where(where)
+                .orderBy(
+                        qChatting.createdAt.desc()
+                )
+                .limit(size)
+                .fetch();
+    }
+
 
     private QRepGetChatsDtoV1 getChattingProjection() {
         return new QRepGetChatsDtoV1(

--- a/chat-service/src/main/java/com/javaauction/chatservice/presentation/controller/ChatControllerV1.java
+++ b/chat-service/src/main/java/com/javaauction/chatservice/presentation/controller/ChatControllerV1.java
@@ -99,13 +99,13 @@ public class ChatControllerV1 {
     }
 
     // SSE 구독
-    @GetMapping(value= "/{chatroomId}/subscribe", produces = "text/event-stream")
-    public SseEmitter getSubscribe(
+    @GetMapping(value="/{chatroomId}/subscribe", produces="text/event-stream")
+    public SseEmitter subscribe(
             @PathVariable UUID chatroomId,
-            @RequestHeader("X-User-Username") String username,
+            @RequestHeader("X-User-Username") String userId,
             @RequestHeader("X-User-Role") String role
     ) {
-        return sseEmitterService.subscribe(chatroomId, username, role);
+        return chatService.subscribeChatroom(chatroomId, userId, role);
     }
 
     // 커서 기반 채팅 리스트 조회

--- a/chat-service/src/main/java/com/javaauction/chatservice/presentation/controller/ChatControllerV1.java
+++ b/chat-service/src/main/java/com/javaauction/chatservice/presentation/controller/ChatControllerV1.java
@@ -1,7 +1,7 @@
 package com.javaauction.chatservice.presentation.controller;
 
 import com.javaauction.chatservice.application.service.ChatServiceV1;
-import com.javaauction.chatservice.application.service.SseEmitterServiceV1;
+import com.javaauction.chatservice.application.event.sse.SseEmitterService;
 import com.javaauction.chatservice.presentation.advice.ChatSuccessCode;
 import com.javaauction.chatservice.presentation.dto.common.ChatroomSearchParam;
 import com.javaauction.chatservice.presentation.dto.common.ChattingSearchParam;
@@ -25,7 +25,7 @@ import java.util.UUID;
 @RequestMapping("/v1/chatrooms")
 public class ChatControllerV1 {
     private final ChatServiceV1 chatService;
-    private final SseEmitterServiceV1 sseEmitterService;
+    private final SseEmitterService sseEmitterService;
 
     // 채팅방 생성
     @PostMapping
@@ -107,4 +107,26 @@ public class ChatControllerV1 {
     ) {
         return sseEmitterService.subscribe(chatroomId, username, role);
     }
+
+    // 커서 기반 채팅 리스트 조회
+    @GetMapping("/{chatroomId}/chats/cursor")
+    public ResponseEntity<ApiResponse<RepGetChatsCursorDtoV1>> getChatsByCursor(
+            @PathVariable UUID chatroomId,
+            @RequestParam(required = false) UUID cursorChattingId,
+            @RequestHeader("X-User-Username") String username,
+            @RequestHeader("X-User-Role") String role
+    ) {
+        RepGetChatsCursorDtoV1 result =
+                chatService.getChatsByCursor(
+                        chatroomId,
+                        cursorChattingId,
+                        username,
+                        role
+                );
+
+        return ResponseEntity.ok(
+                ApiResponse.success(ChatSuccessCode.CHAT_FIND_SUCCESS, result)
+        );
+    }
+
 }

--- a/chat-service/src/main/java/com/javaauction/chatservice/presentation/dto/response/RepGetChatsCursorDtoV1.java
+++ b/chat-service/src/main/java/com/javaauction/chatservice/presentation/dto/response/RepGetChatsCursorDtoV1.java
@@ -1,0 +1,25 @@
+package com.javaauction.chatservice.presentation.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+@Builder
+public class RepGetChatsCursorDtoV1 {
+
+    private List<RepGetChatsDtoV1> chats;
+
+    private Cursor nextCursor;
+
+    private boolean hasNext;
+
+    @Getter
+    @Builder
+    public static class Cursor {
+        private UUID chattingId;
+    }
+}
+

--- a/chat-service/src/main/resources/application.yml
+++ b/chat-service/src/main/resources/application.yml
@@ -27,3 +27,12 @@ eureka:
     fetch-registry: true
     service-url:
       defaultZone: http://localhost:19090/eureka/
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "*"
+  endpoint:
+    health:
+      show-details: always


### PR DESCRIPTION
## 📎 관련 이슈
- 관련 이슈 번호를 연결해주세요.  
  #85 

---

## 📢 개요(Summary)
채팅 서비스 조회 리팩토링

---

## 🔧 변경 사항(Details)
구체적으로 어떤 변경이 이루어졌는지 작성해주세요.

- 채팅방, 채팅 인덱스 적용
- 커서 기반 채팅 리스트 조회 API 구현
- 모니터링 환경설정 추가
- SSE 클래스 event.sse 패키지로 이동 & 구독 권한 chat service에서 체크하도록 로직 분리

---

## ✔️ 테스트 방법(Test)
해당 PR을 검증하기 위해 실행해야 할 테스트 방법을 작성해주세요.

1.  커서 기반 채팅 리스트 : /v1/chats/{chatroomId}/chats/cursor
- Param 없이 데이터 조회 시 해당 채팅방의 가장 최근 채팅 100건을 가져오고, 그 100건 중 가장 오래된 채팅의 ID를 표시한다.
  
<img width="591" height="591" alt="커서기반채팅1" src="https://github.com/user-attachments/assets/ce36f672-ee1e-4d2c-b399-cd94e4bd4f0b" />

- cursorChattingId을 Param으로 보내면 그 이전의 채팅 100건을 추가로 가져온다.
<img width="760" height="593" alt="커서기반채팅2" src="https://github.com/user-attachments/assets/bab96341-e586-4c20-a597-8e124f1707c3" />


2. 채팅방, 채팅 인덱스 적용
- 적용 전 : 채팅방 10만개, 채팅 200만개 더미 데이터로 테스트 시 풀 사이즈 초과, 커넥션 타임아웃으로 에러 발생
<img width="751" height="170" alt="채팅리스트_인덱스적용전" src="https://github.com/user-attachments/assets/0b33a8d3-67fd-498e-a86e-528b5e1ef27d" />

- 적용 후 : 정상 동작
<img width="746" height="164" alt="채팅리스트_인덱스적용후" src="https://github.com/user-attachments/assets/f8afe097-8f7e-419f-876d-e521c891d4ed" />

---
