### PR TITLE
Feat/#124 상품 인기순 조회

### DIFF
--- a/product-service/src/main/java/com/springcloud/eureka/client/productservice/application/scheduler/PopularProductScheduler.java
+++ b/product-service/src/main/java/com/springcloud/eureka/client/productservice/application/scheduler/PopularProductScheduler.java
@@ -1,0 +1,31 @@
+package com.springcloud.eureka.client.productservice.application.scheduler;
+
+import com.springcloud.eureka.client.productservice.application.service.PopularProductService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@EnableScheduling
+@RequiredArgsConstructor
+public class PopularProductScheduler {
+
+    private final PopularProductService popularProductService;
+
+    /**
+     * 인기 상품 목록 주기적 갱신 (10분마다)
+     */
+    @Scheduled(cron = "${popular-products.refresh-cron}")
+    public void refreshPopularProducts() {
+        log.info("=== 인기 상품 목록 갱신 시작 ===");
+        try {
+            popularProductService.refreshPopularProducts();
+            log.info("=== 인기 상품 목록 갱신 완료 ===");
+        } catch (Exception e) {
+            log.error("인기 상품 목록 갱신 실패", e);
+        }
+    }
+}

--- a/product-service/src/main/java/com/springcloud/eureka/client/productservice/application/service/PopularProductService.java
+++ b/product-service/src/main/java/com/springcloud/eureka/client/productservice/application/service/PopularProductService.java
@@ -1,0 +1,104 @@
+package com.springcloud.eureka.client.productservice.application.service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.springcloud.eureka.client.productservice.domain.entity.Product;
+import com.springcloud.eureka.client.productservice.infrastructure.client.PopularProductConfig;
+import com.springcloud.eureka.client.productservice.infrastructure.repository.ProductRepository;
+import com.springcloud.eureka.client.productservice.presentation.dto.RepProductDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PopularProductService {
+
+    private static final String POPULAR_PRODUCTS_KEY = "popular:products:top";
+
+    private final ProductViewService productViewService;
+    private final ProductRepository productRepository;
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final PopularProductConfig config;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * 인기 상품 목록 갱신
+     */
+    @Transactional(readOnly = true)
+    public void refreshPopularProducts() {
+        // 1. 상위 N개 상품 ID 조회
+        Set<String> topProductIds = productViewService.getTopProductIds(config.getTopCount());
+
+        if (topProductIds == null || topProductIds.isEmpty()) {
+            log.warn("인기 상품이 없습니다.");
+            return;
+        }
+
+        // 2. UUID로 변환
+        List<UUID> productUUIDs = topProductIds.stream()
+                .map(UUID::fromString)
+                .collect(Collectors.toList());
+
+        // 3. DB에서 상품 정보 조회
+        List<Product> products = productRepository.findAllById(productUUIDs);
+
+        // 4. DTO 변환 + viewCount 추가 ⭐
+        List<RepProductDto> productDtos = products.stream()
+                .map(product -> {
+                    RepProductDto dto = RepProductDto.from(product);
+                    // Redis에서 조회수 가져와서 설정
+                    Double viewCount = productViewService.getViewCount(product.getId());
+                    dto.setViewCount(viewCount != null ? viewCount.longValue() : 0L);
+                    return dto;
+                })
+                .collect(Collectors.toList());
+
+        // 5. Redis에 캐시 저장
+        redisTemplate.opsForValue().set(
+                POPULAR_PRODUCTS_KEY,
+                productDtos,
+                config.getCacheTtlMinutes(),
+                TimeUnit.MINUTES
+        );
+
+        log.info("=== 인기 상품 {}개 캐시 저장 완료 ===", productDtos.size());
+    }
+
+    /**
+     * 인기 상품 목록 조회
+     */
+    public List<RepProductDto> getPopularProducts() {
+        try {
+            Object cachedData = redisTemplate.opsForValue().get(POPULAR_PRODUCTS_KEY);
+
+            if (cachedData == null) {
+                log.warn("인기 상품 캐시가 비어있습니다. 갱신 시작...");
+                refreshPopularProducts();
+                cachedData = redisTemplate.opsForValue().get(POPULAR_PRODUCTS_KEY);
+            }
+
+            if (cachedData == null) {
+                return List.of();
+            }
+
+            return objectMapper.convertValue(
+                    cachedData,
+                    new TypeReference<List<RepProductDto>>() {}
+            );
+
+        } catch (Exception e) {
+            log.error("인기 상품 조회 실패", e);
+            return List.of();
+        }
+    }
+}

--- a/product-service/src/main/java/com/springcloud/eureka/client/productservice/application/service/PopularProductService.java
+++ b/product-service/src/main/java/com/springcloud/eureka/client/productservice/application/service/PopularProductService.java
@@ -12,6 +12,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -52,7 +53,7 @@ public class PopularProductService {
         // 3. DB에서 상품 정보 조회
         List<Product> products = productRepository.findAllById(productUUIDs);
 
-        // 4. DTO 변환 + viewCount 추가 ⭐
+        // 4. DTO 변환 + viewCount 추가
         List<RepProductDto> productDtos = products.stream()
                 .map(product -> {
                     RepProductDto dto = RepProductDto.from(product);
@@ -61,6 +62,7 @@ public class PopularProductService {
                     dto.setViewCount(viewCount != null ? viewCount.longValue() : 0L);
                     return dto;
                 })
+                .sorted(Comparator.comparing(RepProductDto::getViewCount).reversed())
                 .collect(Collectors.toList());
 
         // 5. Redis에 캐시 저장

--- a/product-service/src/main/java/com/springcloud/eureka/client/productservice/application/service/ProductService.java
+++ b/product-service/src/main/java/com/springcloud/eureka/client/productservice/application/service/ProductService.java
@@ -12,7 +12,6 @@ import com.springcloud.eureka.client.productservice.infrastructure.s3.S3ImageUpl
 import com.springcloud.eureka.client.productservice.presentation.dto.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
-import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;

--- a/product-service/src/main/java/com/springcloud/eureka/client/productservice/application/service/ProductService.java
+++ b/product-service/src/main/java/com/springcloud/eureka/client/productservice/application/service/ProductService.java
@@ -12,6 +12,7 @@ import com.springcloud.eureka.client.productservice.infrastructure.s3.S3ImageUpl
 import com.springcloud.eureka.client.productservice.presentation.dto.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -32,6 +33,7 @@ public class ProductService {
     private final ProductCategoryRepository categoryRepository;
     private final UserServiceClient userServiceClient;
     private final S3ImageUploader s3ImageUploader;
+    private final ProductViewService productViewService;
 
     // 상품 생성
     public RepProductDto createProduct(String username, ReqProductCreateDto request, MultipartFile file){
@@ -57,8 +59,13 @@ public class ProductService {
     public RepProductDto getProduct(UUID productId){
         Product product = productRepository.findById(productId)
                 .orElseThrow(() -> new BussinessException(ProductErrorCode.PRODUCT_NOT_FOUND));
+
         return RepProductDto.from(product);
     }
+
+
+
+
 
     // 상품 목록 조회 (검색/상태, 카테고리는 나중에)
     @Transactional(readOnly = true)
@@ -80,7 +87,16 @@ public class ProductService {
             }
         }
 
-        Page<RepProductDto> mapped = result.map(RepProductDto::from);
+        Page<RepProductDto> mapped = result.map(product -> {
+            RepProductDto dto = RepProductDto.from(product);
+
+            // Redis에서 조회수 가져오기
+            Double viewCount = productViewService.getViewCount(product.getId());
+            dto.setViewCount(viewCount != null ? viewCount.longValue() : 0L);
+
+            return dto;
+        });
+
         return RepProductPageDto.from(mapped);
     }
 

--- a/product-service/src/main/java/com/springcloud/eureka/client/productservice/application/service/ProductViewService.java
+++ b/product-service/src/main/java/com/springcloud/eureka/client/productservice/application/service/ProductViewService.java
@@ -1,0 +1,65 @@
+package com.springcloud.eureka.client.productservice.application.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.Set;
+import java.util.UUID;
+
+@Slf4j
+@Service
+public class ProductViewService {
+
+    private static final String VIEW_RANKING_KEY = "product:view_ranking";
+
+    private final StringRedisTemplate stringRedisTemplate;
+
+    public ProductViewService(StringRedisTemplate stringRedisTemplate) {
+        this.stringRedisTemplate = stringRedisTemplate;
+        log.info("=== ProductViewService 생성! ===");
+        testRedisConnection();
+    }
+
+    private void testRedisConnection() {
+        try {
+            log.info("=== Redis 연결 테스트 시작! ===");
+            String pong = stringRedisTemplate.getConnectionFactory()
+                    .getConnection().ping();
+            log.info("=== PING 결과: {} ===", pong);
+
+            Set<String> keys = stringRedisTemplate.keys("*");
+            log.info("=== 전체 키: {} ===", keys);
+            log.info("=== Redis 연결 테스트 성공! ===");
+
+        } catch (Exception e) {
+            log.error("=== Redis 연결 테스트 실패! ===", e);
+        }
+    }
+
+    public void incrementViewCount(UUID productId) {
+        try {
+            log.info("=== 조회수 증가 시작: {} ===", productId);
+
+            // ZINCRBY: 없으면 0에서 시작, 있으면 기존 값에 +1
+            Double result = stringRedisTemplate.opsForZSet()
+                    .incrementScore(VIEW_RANKING_KEY, productId.toString(), 1.0);
+
+            log.info("=== ZINCRBY 결과: {} ===", result);
+
+        } catch (Exception e) {
+            log.error("=== 조회수 증가 실패: {} ===", productId, e);
+        }
+    }
+
+    public Set<String> getTopProductIds(int topCount) {
+        Set<String> result = stringRedisTemplate.opsForZSet()
+                .reverseRange(VIEW_RANKING_KEY, 0, topCount - 1);
+        return result != null ? result : Set.of();
+    }
+
+    public Double getViewCount(UUID productId) {
+        return stringRedisTemplate.opsForZSet()
+                .score(VIEW_RANKING_KEY, productId.toString());
+    }
+}

--- a/product-service/src/main/java/com/springcloud/eureka/client/productservice/infrastructure/client/PopularProductConfig.java
+++ b/product-service/src/main/java/com/springcloud/eureka/client/productservice/infrastructure/client/PopularProductConfig.java
@@ -1,0 +1,16 @@
+package com.springcloud.eureka.client.productservice.infrastructure.client;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Getter
+@Setter
+@Configuration
+@ConfigurationProperties(prefix = "popular-products")
+public class PopularProductConfig {
+    private int topCount = 10;
+    private int cacheTtlMinutes = 60;
+    private String refreshCron = "0 */10 * * * *";
+}

--- a/product-service/src/main/java/com/springcloud/eureka/client/productservice/infrastructure/client/RedisCacheConfig.java
+++ b/product-service/src/main/java/com/springcloud/eureka/client/productservice/infrastructure/client/RedisCacheConfig.java
@@ -46,12 +46,12 @@ public class RedisCacheConfig {
         return factory;
     }
 
-    // ⭐ ObjectMapper Bean 생성 (JavaTimeModule 포함)
+    // ObjectMapper Bean 생성 (JavaTimeModule 포함)
     @Bean
     public ObjectMapper redisObjectMapper() {
         ObjectMapper objectMapper = new ObjectMapper();
 
-        // ⭐ JavaTimeModule 등록 (Instant, LocalDateTime 등 처리)
+        // JavaTimeModule 등록 (Instant, LocalDateTime 등 처리)
         objectMapper.registerModule(new JavaTimeModule());
 
         // Timestamp 대신 ISO-8601 형식으로 직렬화
@@ -71,7 +71,7 @@ public class RedisCacheConfig {
         return objectMapper;
     }
 
-    // ⭐ RedisCacheManager (캐싱용)
+    // RedisCacheManager (캐싱용)
     @Bean
     public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
         GenericJackson2JsonRedisSerializer serializer =
@@ -92,7 +92,7 @@ public class RedisCacheConfig {
                 .build();
     }
 
-    // ⭐ 조회수 전용 RedisTemplate (String/String)
+    // 조회수 전용 RedisTemplate (String/String)
     @Primary
     @Bean("viewCountRedisTemplate")
     public RedisTemplate<String, String> viewCountRedisTemplate(RedisConnectionFactory connectionFactory) {
@@ -112,7 +112,7 @@ public class RedisCacheConfig {
         return template;
     }
 
-    // ⭐ 일반 RedisTemplate (Object 저장용)
+    // 일반 RedisTemplate (Object 저장용)
     @Bean
     public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
         RedisTemplate<String, Object> template = new RedisTemplate<>();

--- a/product-service/src/main/java/com/springcloud/eureka/client/productservice/infrastructure/client/RedisCacheConfig.java
+++ b/product-service/src/main/java/com/springcloud/eureka/client/productservice/infrastructure/client/RedisCacheConfig.java
@@ -1,16 +1,23 @@
 package com.springcloud.eureka.client.productservice.infrastructure.client;
 
+
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
@@ -21,16 +28,36 @@ import java.time.Duration;
 @EnableCaching
 public class RedisCacheConfig {
 
+    @Value("${spring.data.redis.host:localhost}")
+    private String host;
+
+    @Value("${spring.data.redis.port:6379}")
+    private int port;
+
     @Bean
-    public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
-        // ObjectMapper 설정
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration();
+        config.setHostName(host);
+        config.setPort(port);
+        config.setDatabase(0);
+
+        LettuceConnectionFactory factory = new LettuceConnectionFactory(config);
+        factory.setValidateConnection(true);
+        return factory;
+    }
+
+    // ⭐ ObjectMapper Bean 생성 (JavaTimeModule 포함)
+    @Bean
+    public ObjectMapper redisObjectMapper() {
         ObjectMapper objectMapper = new ObjectMapper();
 
-        // Java 8 날짜/시간 타입 지원
+        // ⭐ JavaTimeModule 등록 (Instant, LocalDateTime 등 처리)
         objectMapper.registerModule(new JavaTimeModule());
+
+        // Timestamp 대신 ISO-8601 형식으로 직렬화
         objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
 
-        // 타입 정보 포함 (LinkedHashMap 문제 해결)
+        // 타입 정보 포함 (역직렬화 시 타입 보존)
         BasicPolymorphicTypeValidator validator = BasicPolymorphicTypeValidator.builder()
                 .allowIfSubType(Object.class)
                 .build();
@@ -41,23 +68,77 @@ public class RedisCacheConfig {
                 JsonTypeInfo.As.PROPERTY
         );
 
-        GenericJackson2JsonRedisSerializer serializer =
-                new GenericJackson2JsonRedisSerializer(objectMapper);
+        return objectMapper;
+    }
 
-        RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
+    // ⭐ RedisCacheManager (캐싱용)
+    @Bean
+    public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+        GenericJackson2JsonRedisSerializer serializer =
+                new GenericJackson2JsonRedisSerializer(redisObjectMapper());
+
+        RedisCacheConfiguration cacheConfig = RedisCacheConfiguration.defaultCacheConfig()
                 .entryTtl(Duration.ofMinutes(10))
                 .disableCachingNullValues()
                 .serializeKeysWith(
-                        RedisSerializationContext.SerializationPair
-                                .fromSerializer(new StringRedisSerializer())
+                        RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer())
                 )
                 .serializeValuesWith(
-                        RedisSerializationContext.SerializationPair
-                                .fromSerializer(serializer)
+                        RedisSerializationContext.SerializationPair.fromSerializer(serializer)
                 );
 
         return RedisCacheManager.builder(connectionFactory)
-                .cacheDefaults(config)
+                .cacheDefaults(cacheConfig)
                 .build();
     }
+
+    // ⭐ 조회수 전용 RedisTemplate (String/String)
+    @Primary
+    @Bean("viewCountRedisTemplate")
+    public RedisTemplate<String, String> viewCountRedisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+
+        StringRedisSerializer stringSerializer = new StringRedisSerializer();
+
+        template.setKeySerializer(stringSerializer);
+        template.setValueSerializer(stringSerializer);
+        template.setHashKeySerializer(stringSerializer);
+        template.setHashValueSerializer(stringSerializer);
+
+        template.setEnableTransactionSupport(false);
+        template.afterPropertiesSet();
+
+        return template;
+    }
+
+    // ⭐ 일반 RedisTemplate (Object 저장용)
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+
+        StringRedisSerializer stringSerializer = new StringRedisSerializer();
+        GenericJackson2JsonRedisSerializer jsonSerializer =
+                new GenericJackson2JsonRedisSerializer(redisObjectMapper());
+
+        template.setKeySerializer(stringSerializer);
+        template.setValueSerializer(jsonSerializer);
+        template.setHashKeySerializer(stringSerializer);
+        template.setHashValueSerializer(jsonSerializer);
+
+        template.setEnableTransactionSupport(false);
+        template.afterPropertiesSet();
+
+        return template;
+    }
+
+
+    @Bean
+    public StringRedisTemplate stringRedisTemplate(RedisConnectionFactory connectionFactory) {
+        StringRedisTemplate template = new StringRedisTemplate(connectionFactory);
+        template.setEnableTransactionSupport(false);
+        return template;
+    }
+
 }

--- a/product-service/src/main/java/com/springcloud/eureka/client/productservice/presentation/controller/ProductController.java
+++ b/product-service/src/main/java/com/springcloud/eureka/client/productservice/presentation/controller/ProductController.java
@@ -2,7 +2,9 @@ package com.springcloud.eureka.client.productservice.presentation.controller;
 
 import com.javaauction.global.infrastructure.code.BaseSuccessCode;
 import com.javaauction.global.presentation.response.ApiResponse;
+import com.springcloud.eureka.client.productservice.application.service.PopularProductService;
 import com.springcloud.eureka.client.productservice.application.service.ProductService;
+import com.springcloud.eureka.client.productservice.application.service.ProductViewService;
 import com.springcloud.eureka.client.productservice.domain.enums.ProductStatus;
 import com.springcloud.eureka.client.productservice.presentation.dto.*;
 import lombok.RequiredArgsConstructor;
@@ -10,6 +12,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -19,6 +22,8 @@ import java.util.UUID;
 public class ProductController {
 
     private final ProductService productService;
+    private final PopularProductService popularProductService;
+    private final ProductViewService productViewService;  // 추가!
 
     // 상품 등록
     @PostMapping(consumes = "multipart/form-data")
@@ -35,14 +40,24 @@ public class ProductController {
 
     // 상품 단건 조회
     @GetMapping("/{productId}")
-    public ResponseEntity<ApiResponse<RepProductDto>> getProduct(
-            @PathVariable UUID productId
-    ) {
-        RepProductDto response = productService.getProduct(productId);
-        return ResponseEntity.ok(ApiResponse.success(BaseSuccessCode.OK, response));
+    public ResponseEntity<ApiResponse<RepProductDto>> getProduct(@PathVariable UUID productId) {
+
+        // 1. 조회수 증가 (매번 실행!)
+        productViewService.incrementViewCount(productId);
+
+        // 2. 상품 조회 (캐시 활용!)
+        RepProductDto dto = productService.getProduct(productId);
+
+        // 3. 조회수 설정 (Redis에서 가져옴)
+        Double viewCount = productViewService.getViewCount(productId);
+        if (viewCount != null) {
+            dto.setViewCount(viewCount.longValue());
+        }
+
+        return ResponseEntity.ok(ApiResponse.success(BaseSuccessCode.OK, dto));
     }
 
-    // 상품 목록 조회 (검색/상태, 카테고리 제외)
+    // 상품 목록 조회
     @GetMapping
     public ResponseEntity<ApiResponse<RepProductPageDto>> getProducts(
             @RequestParam(required = false) String keyword,
@@ -53,6 +68,13 @@ public class ProductController {
         RepProductPageDto response =
                 productService.getProducts(keyword, status, page, size);
 
+        return ResponseEntity.ok(ApiResponse.success(BaseSuccessCode.OK, response));
+    }
+
+    // 인기 상품 목록 조회
+    @GetMapping("/popular")
+    public ResponseEntity<ApiResponse<List<RepProductDto>>> getPopularProducts() {
+        List<RepProductDto> response = popularProductService.getPopularProducts();
         return ResponseEntity.ok(ApiResponse.success(BaseSuccessCode.OK, response));
     }
 

--- a/product-service/src/main/java/com/springcloud/eureka/client/productservice/presentation/dto/RepProductDto.java
+++ b/product-service/src/main/java/com/springcloud/eureka/client/productservice/presentation/dto/RepProductDto.java
@@ -28,6 +28,9 @@ public class RepProductDto {
     private Instant updatedAt;
     private Instant deletedAt;
 
+    // 조회수 추가 (Redis에서만 가져옴!)
+    private Long viewCount;
+
     public static RepProductDto from(Product product) {
         return RepProductDto.builder()
                 .productId(product.getId())
@@ -43,5 +46,10 @@ public class RepProductDto {
                 .updatedAt(product.getUpdatedAt())
                 .deletedAt(product.getDeletedAt())
                 .build();
+    }
+
+    // 조회수 설정용 메서드
+    public void setViewCount(Long viewCount) {
+        this.viewCount = viewCount;
     }
 }

--- a/product-service/src/main/resources/application.yml
+++ b/product-service/src/main/resources/application.yml
@@ -17,8 +17,9 @@ spring:
   # Redis 설정 추가 (여기부터 새로 추가)
   data:
     redis:
-      host: localhost  # 로컬 IntelliJ 실행 시
+      host: localhost # 로컬 IntelliJ 실행 시
       port: 6379
+      database: 0
       timeout: 3000ms
 
   cache:
@@ -52,3 +53,8 @@ management:
   endpoint:
     health:
       show-details: always
+
+popular-products:
+  top-count: 10  # 상위 N개
+  cache-ttl-minutes: 60  # 캐시 유효 시간 (1시간)
+  refresh-cron: "0 */10 * * * *"  # 10분마다 갱신


### PR DESCRIPTION
## 📎 관련 이슈
- 관련 이슈 번호를 연결해주세요.  
  #124

---

## 📢 개요(Summary)
- Redis Sorted Set을 활용해 상품 조회수를 저장·조회하는 기능을 추가
- 인기 상품(Top 10) 목록을 캐시로 관리하고, 일정 주기로 자동 갱신되도록 구현
- 단건/목록/인기 상품 조회 API 응답에 viewCount를 포함하도록 수정

---

## 🔧 변경 사항(Details)

- **상품 조회수 추적 서비스 추가**
  - `ProductViewService`를 추가하여 상품 조회 시 Redis에 조회수를 증가시키고, 상품별/다수 상품의 조회수를 조회할 수 있도록 구현했습니다.
  - Redis Sorted Set(`product:view_ranking`)을 사용해 조회수 기반 인기 상품 랭킹을 관리하도록 했습니다.

- **인기 상품 캐싱 및 자동 갱신 기능 구현**
  - `PopularProductService`, `PopularProductScheduler`를 추가하여 조회수 상위 10개의 상품을 조회하고, DTO로 변환 후 캐시에 저장하는 기능을 구현했습니다.
  - 스케줄러로 10분마다 인기 상품 캐시를 자동 갱신하도록 했습니다.

- **상품 조회 API에 viewCount 포함**
  - `RepProductDto`에 `viewCount` 필드를 추가하고, `ProductService`에서 단건/목록 조회 시 Redis에서 조회수를 조회해 DTO에 매핑하도록 수정했습니다.
  - `ProductController`에 인기 상품 조회 엔드포인트(`GET /v1/products/popular`)를 추가하고, 기존 상품 목록/단건 조회 응답에 조회수가 포함되도록 응답 스펙을 확장했습니다.

---


## ✔️ 테스트 방법(Test)

### 상품 조회시 조회수 증가
<img width="717" height="801" alt="image" src="https://github.com/user-attachments/assets/c65eb733-8548-4962-a143-a61ee3945c4a" />

### 조회수 기준 인기상품 10개만 조회
<img width="697" height="805" alt="image" src="https://github.com/user-attachments/assets/01657c15-873e-47fc-96fd-80da95d223c6" />
 
---
